### PR TITLE
Convert to a sync.pool, tweak proto dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,17 @@ module github.com/honeycombio/husky
 go 1.17
 
 require (
-	github.com/golang/protobuf v1.5.2
-	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/klauspost/compress v1.13.6
 	go.opentelemetry.io/proto/otlp v0.9.0
+	google.golang.org/grpc v1.37.1
+	google.golang.org/protobuf v1.26.0
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
 	golang.org/x/text v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.37.1
-	google.golang.org/protobuf v1.26.0 // indirect
 )


### PR DESCRIPTION
This is a change to use a package-local sync.Pool of *zstd.Decoder. 

Also changed to the preferred golang/protobuf. 

@MikeGoldsmith this is what I was thinking. Happy to discuss at your convenience.

