### PR TITLE
Add content-encoding and grpc-accept-encoding to RequestInfo

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -26,7 +26,7 @@ type RequestInfo struct {
 	UserAgent          string
 	ContentType        string
 	ContentEncoding    string
-	GrpcAcceptEncoding string
+	GRPCAcceptEncoding string
 }
 
 func (ri *RequestInfo) HasValidContentType() bool {
@@ -43,7 +43,7 @@ func GetRequestInfoFromGrpcMetadata(ctx context.Context) RequestInfo {
 		ri.ProxyToken = getValueFromMetadata(md, proxyTokenHeader)
 		ri.UserAgent = getValueFromMetadata(md, userAgentHeader)
 		ri.ContentEncoding = getValueFromMetadata(md, contentEncodingHeader)
-		ri.GrpcAcceptEncoding = getValueFromMetadata(md, gRPCAcceptEncodingHeader)
+		ri.GRPCAcceptEncoding = getValueFromMetadata(md, gRPCAcceptEncodingHeader)
 	}
 	return ri
 }
@@ -56,7 +56,7 @@ func GetRequestInfoFromHttpHeaders(r *http.Request) RequestInfo {
 		UserAgent:          r.Header.Get(userAgentHeader),
 		ContentType:        r.Header.Get(contentTypeHeader),
 		ContentEncoding:    r.Header.Get(contentEncodingHeader),
-		GrpcAcceptEncoding: r.Header.Get(gRPCAcceptEncodingHeader),
+		GRPCAcceptEncoding: r.Header.Get(gRPCAcceptEncodingHeader),
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
Adds useful additional fields to the RequestInfo struct.

## Short description of the changes
- adds `content-type` and `grpc-accept-encoding` to RequestInfo struct
- populate both headers when parsing HTTP / gRPC request
- standardise header keys to have `Header` suffix

