### PR TITLE
Make bytesToTraceID public

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -56,7 +56,7 @@ func TranslateGrpcTraceRequest(request *collectorTrace.ExportTraceServiceRequest
 			}
 
 			for _, span := range librarySpan.GetSpans() {
-				traceID := bytesToTraceID(span.TraceId)
+				traceID := BytesToTraceID(span.TraceId)
 				spanID := hex.EncodeToString(span.SpanId)
 
 				spanKind := getSpanKind(span.Kind)
@@ -122,7 +122,7 @@ func TranslateGrpcTraceRequest(request *collectorTrace.ExportTraceServiceRequest
 					attrs := map[string]interface{}{
 						"trace.trace_id":       traceID,
 						"trace.parent_id":      spanID,
-						"trace.link.trace_id":  bytesToTraceID(slink.TraceId),
+						"trace.link.trace_id":  BytesToTraceID(slink.TraceId),
 						"trace.link.span_id":   hex.EncodeToString(slink.SpanId),
 						"parent_name":          span.Name,
 						"meta.annotation_type": "link",
@@ -164,14 +164,14 @@ func getSpanKind(kind trace.Span_SpanKind) string {
 	}
 }
 
-// bytesToTraceID returns an ID suitable for use for spans and traces. Before
+// BytesToTraceID returns an ID suitable for use for spans and traces. Before
 // encoding the bytes as a hex string, we want to handle cases where we are
 // given 128-bit IDs with zero padding, e.g. 0000000000000000f798a1e7f33c8af6.
 // There are many ways to achieve this, but careful benchmarking and testing
 // showed the below as the most performant, avoiding memory allocations
 // and the use of flexible but expensive library functions. As this is hot code,
 // it seemed worthwhile to do it this way.
-func bytesToTraceID(traceID []byte) string {
+func BytesToTraceID(traceID []byte) string {
 	var encoded []byte
 	switch len(traceID) {
 	case traceIDLongLength: // 16 bytes, trim leading 8 bytes if all 0's

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -91,7 +91,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	var ev event
 	ev = getEventAtIndex(events, 0)
 	assert.Equal(t, starTimestamp.Nanosecond(), ev.time.Nanosecond())
-	assert.Equal(t, bytesToTraceID(traceID), ev.data["trace.trace_id"])
+	assert.Equal(t, BytesToTraceID(traceID), ev.data["trace.trace_id"])
 	assert.Equal(t, hex.EncodeToString(spanID), ev.data["trace.span_id"])
 	assert.Equal(t, "client", ev.data["type"])
 	assert.Equal(t, "client", ev.data["span.kind"])
@@ -103,7 +103,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 
 	// event
 	ev = getEventAtIndex(events, 1)
-	assert.Equal(t, bytesToTraceID(traceID), ev.data["trace.trace_id"])
+	assert.Equal(t, BytesToTraceID(traceID), ev.data["trace.trace_id"])
 	assert.Equal(t, hex.EncodeToString(spanID), ev.data["trace.parent_id"])
 	assert.Equal(t, "span_event", ev.data["name"])
 	assert.Equal(t, "test_span", ev.data["parent_name"])
@@ -114,9 +114,9 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	// link
 	ev = getEventAtIndex(events, 2)
 	assert.Equal(t, starTimestamp.Nanosecond(), ev.time.Nanosecond())
-	assert.Equal(t, bytesToTraceID(traceID), ev.data["trace.trace_id"])
+	assert.Equal(t, BytesToTraceID(traceID), ev.data["trace.trace_id"])
 	assert.Equal(t, hex.EncodeToString(spanID), ev.data["trace.parent_id"])
-	assert.Equal(t, bytesToTraceID(linkedTraceID), ev.data["trace.link.trace_id"])
+	assert.Equal(t, BytesToTraceID(linkedTraceID), ev.data["trace.link.trace_id"])
 	assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.data["trace.link.span_id"])
 	assert.Equal(t, "test_span", ev.data["parent_name"])
 	assert.Equal(t, "link", ev.data["meta.annotation_type"])
@@ -213,7 +213,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 			var ev event
 			ev = getEventAtIndex(events, 0)
 			assert.Equal(t, starTimestamp.Nanosecond(), ev.time.Nanosecond())
-			assert.Equal(t, bytesToTraceID(traceID), ev.data["trace.trace_id"])
+			assert.Equal(t, BytesToTraceID(traceID), ev.data["trace.trace_id"])
 			assert.Equal(t, hex.EncodeToString(spanID), ev.data["trace.span_id"])
 			assert.Equal(t, "client", ev.data["type"])
 			assert.Equal(t, "client", ev.data["span.kind"])
@@ -225,7 +225,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 
 			// event
 			ev = getEventAtIndex(events, 1)
-			assert.Equal(t, bytesToTraceID(traceID), ev.data["trace.trace_id"])
+			assert.Equal(t, BytesToTraceID(traceID), ev.data["trace.trace_id"])
 			assert.Equal(t, hex.EncodeToString(spanID), ev.data["trace.parent_id"])
 			assert.Equal(t, "span_event", ev.data["name"])
 			assert.Equal(t, "test_span", ev.data["parent_name"])
@@ -235,9 +235,9 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 
 			// link
 			ev = getEventAtIndex(events, 2)
-			assert.Equal(t, bytesToTraceID(traceID), ev.data["trace.trace_id"])
+			assert.Equal(t, BytesToTraceID(traceID), ev.data["trace.trace_id"])
 			assert.Equal(t, hex.EncodeToString(spanID), ev.data["trace.parent_id"])
-			assert.Equal(t, bytesToTraceID(linkedTraceID), ev.data["trace.link.trace_id"])
+			assert.Equal(t, BytesToTraceID(linkedTraceID), ev.data["trace.link.trace_id"])
 			assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.data["trace.link.span_id"])
 			assert.Equal(t, "test_span", ev.data["parent_name"])
 			assert.Equal(t, "link", ev.data["meta.annotation_type"])


### PR DESCRIPTION
## Which problem is this PR solving?
`BytesToTraceID` is a useful utility that is used to convert a TraceID encoded as a []byte to a hex string. Making it public would allow users of the module to use it when verifying data.

## Short description of the changes
- make BytesToTraceID public and update internal usage

