### PR TITLE
Add error support

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -33,6 +33,16 @@ func (ri *RequestInfo) HasValidContentType() bool {
 	return ri.ContentType == "application/protobuf" || ri.ContentType == "application/x-protobuf"
 }
 
+func (ri *RequestInfo) ValidateHeaders() error {
+	if len(ri.ApiKey) == 0 {
+		return ErrMissingAPIKeyHeader
+	}
+	if len(ri.Dataset) == 0 {
+		return ErrMissingDatasetHeader
+	}
+	return nil
+}
+
 func GetRequestInfoFromGrpcMetadata(ctx context.Context) RequestInfo {
 	ri := RequestInfo{
 		ContentType: "application/protobuf",

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -131,3 +131,22 @@ func TestAddAttributesToMap(t *testing.T) {
 		assert.Equal(t, tc.expected, attrs[tc.key])
 	}
 }
+
+func TestValidateHeaders(t *testing.T) {
+	testCases := []struct {
+		apikey  string
+		dataset string
+		err     error
+	}{
+		{apikey: "", dataset: "", err: ErrMissingAPIKeyHeader},
+		{apikey: "apikey", dataset: "", err: ErrMissingDatasetHeader},
+		{apikey: "", dataset: "dataset", err: ErrMissingAPIKeyHeader},
+		{apikey: "apikey", dataset: "dataset", err: nil},
+	}
+
+	for _, tc := range testCases {
+		ri := RequestInfo{ApiKey: tc.apikey, Dataset: tc.dataset}
+		err := ri.ValidateHeaders()
+		assert.Equal(t, tc.err, err)
+	}
+}

--- a/otlp/errors.go
+++ b/otlp/errors.go
@@ -1,0 +1,37 @@
+package otlp
+
+import (
+	"fmt"
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type OTLPError struct {
+	message        string
+	httpStatusCode int
+	grpcStatusCode codes.Code
+}
+
+var (
+	ErrInvalidContentType   = OTLPError{"invalid content-type - only 'application/protobuf' is supported", http.StatusNotImplemented, codes.Unimplemented}
+	ErrFailedParseBody      = OTLPError{"failed to parse OTLP request body", http.StatusBadRequest, codes.Internal}
+	ErrMissingAPIKeyHeader  = OTLPError{"missing 'x-honeycomb-team' header", http.StatusUnauthorized, codes.Unauthenticated}
+	ErrMissingDatasetHeader = OTLPError{"missing 'x-honeycomb-dataset' header", http.StatusUnauthorized, codes.Unauthenticated}
+)
+
+func (e OTLPError) Error() string {
+	return e.message
+}
+
+func AsJson(e error) string {
+	return fmt.Sprintf(`{"message":"%s"}`, e.Error())
+}
+
+func AsGRPCError(e error) error {
+	if otlpErr, ok := e.(OTLPError); ok {
+		return status.Error(otlpErr.grpcStatusCode, otlpErr.message)
+	}
+	return status.Error(codes.Internal, "")
+}

--- a/otlp/errors.go
+++ b/otlp/errors.go
@@ -9,9 +9,9 @@ import (
 )
 
 type OTLPError struct {
-	message        string
-	httpStatusCode int
-	grpcStatusCode codes.Code
+	Message        string
+	HTTPStatusCode int
+	GRPCStatusCode codes.Code
 }
 
 var (
@@ -22,7 +22,7 @@ var (
 )
 
 func (e OTLPError) Error() string {
-	return e.message
+	return e.Message
 }
 
 func AsJson(e error) string {
@@ -31,7 +31,7 @@ func AsJson(e error) string {
 
 func AsGRPCError(e error) error {
 	if otlpErr, ok := e.(OTLPError); ok {
-		return status.Error(otlpErr.grpcStatusCode, otlpErr.message)
+		return status.Error(otlpErr.GRPCStatusCode, otlpErr.Message)
 	}
 	return status.Error(codes.Internal, "")
 }

--- a/otlp/errors_test.go
+++ b/otlp/errors_test.go
@@ -1,0 +1,24 @@
+package otlp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+)
+
+func TestErrorsReturnJson(t *testing.T) {
+	err := OTLPError{message: "test-message"}
+	assert.Equal(t, `{"message":"test-message"}`, AsJson(err))
+}
+
+func TestAsGRPCError(t *testing.T) {
+	err := OTLPError{message: "otlp-error", grpcStatusCode: codes.InvalidArgument}
+	assert.Equal(t, "rpc error: code = InvalidArgument desc = otlp-error", AsGRPCError(err).Error())
+}
+
+func TestNonOTLPErrorAsGRPCError(t *testing.T) {
+	err := errors.New("base-error")
+	assert.Equal(t, "rpc error: code = Internal desc = ", AsGRPCError(err).Error())
+}

--- a/otlp/errors_test.go
+++ b/otlp/errors_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestErrorsReturnJson(t *testing.T) {
-	err := OTLPError{message: "test-message"}
+	err := OTLPError{Message: "test-message"}
 	assert.Equal(t, `{"message":"test-message"}`, AsJson(err))
 }
 
 func TestAsGRPCError(t *testing.T) {
-	err := OTLPError{message: "otlp-error", grpcStatusCode: codes.InvalidArgument}
+	err := OTLPError{Message: "otlp-error", GRPCStatusCode: codes.InvalidArgument}
 	assert.Equal(t, "rpc error: code = InvalidArgument desc = otlp-error", AsGRPCError(err).Error())
 }
 

--- a/otlp/errors_test.go
+++ b/otlp/errors_test.go
@@ -18,7 +18,7 @@ func TestAsGRPCError(t *testing.T) {
 	assert.Equal(t, "rpc error: code = InvalidArgument desc = otlp-error", AsGRPCError(err).Error())
 }
 
-func TestNonOTLPErrorAsGRPCError(t *testing.T) {
+func TestNonOTLPErrorReturnsStandardError(t *testing.T) {
 	err := errors.New("base-error")
 	assert.Equal(t, "rpc error: code = Internal desc = ", AsGRPCError(err).Error())
 }

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/hex"
-	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -24,12 +23,12 @@ const (
 func TranslateHttpTraceRequest(req *http.Request) ([]map[string]interface{}, error) {
 	reqInfo := GetRequestInfoFromHttpHeaders(req)
 	if !reqInfo.HasValidContentType() {
-		return nil, errors.New("invalid content-type")
+		return nil, ErrInvalidContentType
 	}
 
 	request, err := parseOTLPBody(req)
 	if err != nil {
-		return nil, errors.New("parse error")
+		return nil, ErrFailedParseBody
 	}
 
 	return TranslateGrpcTraceRequest(request)

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -247,6 +247,26 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 	}
 }
 
+func TestInvalidContentTypeReturnsError(t *testing.T) {
+	body, _ := proto.Marshal(&collectortrace.ExportTraceServiceRequest{})
+	request, _ := http.NewRequest("POST", "", io.NopCloser(bytes.NewReader(body)))
+	request.Header.Set("content-type", "application/json")
+
+	batch, err := TranslateHttpTraceRequest(request)
+	assert.Nil(t, batch)
+	assert.Equal(t, ErrInvalidContentType, err)
+}
+
+func TestInvalidBodyReturnsError(t *testing.T) {
+	body := test.RandomBytes(10)
+	request, _ := http.NewRequest("POST", "", io.NopCloser(bytes.NewReader(body)))
+	request.Header.Set("content-type", "application/protobuf")
+
+	batch, err := TranslateHttpTraceRequest(request)
+	assert.Nil(t, batch)
+	assert.Equal(t, ErrFailedParseBody, err)
+}
+
 func getEventAtIndex(events []map[string]interface{}, i int) event {
 	return event{
 		time: events[i]["time"].(time.Time),


### PR DESCRIPTION
## Which problem is this PR solving?
Adds new `OTLPError` struct that contains a message, HTTP and GRPC status codes. Created reusable errors for standard use cases (content type, required headers, etc).

## Short description of the changes
- Add new `OTLPError` type
- Add standard errors for content-type, required headers, etc
- Return new errors from trace and common funcs

