### PR TITLE
Remove dependency on http.Request

### DIFF
--- a/otlp/README.md
+++ b/otlp/README.md
@@ -7,23 +7,23 @@ This makes consuming the OTLP wire format easier and more consistent.
 
 You can either provide the OTLP trace request directly or a HTTP request object that contains the request in the body.
 
-```
+```go
 // HTTP Request
 ri := GetRequestInfoFromHttpHeaders(request.header) // (request.header http.Header)
 res, err := TranslateHttpTraceRequest(request.body, ri) //(request.body io.Reader, ri RequestInfo)
 
 // OTLP Trace gRPC
-res, err := TranslateGrpcTraceRequest(request *collectorTrace.ExportTraceServiceRequest)
+res, err := TranslateGrpcTraceRequest(request) // (request *collectorTrace.ExportTraceServiceRequest)
 ```
 
 ### Common
 
 The library also includes generic ways to extract request information (API Key, Dataset, etc).
 
-```
+```go
 // HTTP request
 requestInfo := GetRequestInfoFromHttpHeaders(header) // (header http.Header)
 
 // gRPC request context
-requestInfo := GetRequestInfoFromGrpcMetadata(ctx context.Context)
+requestInfo := GetRequestInfoFromGrpcMetadata(ctx) // (ctx context.Context)
 ```

--- a/otlp/README.md
+++ b/otlp/README.md
@@ -9,7 +9,8 @@ You can either provide the OTLP trace request directly or a HTTP request object 
 
 ```
 // HTTP Request
-res, err := TranslateHttpTraceRequest(req *http.Request)
+ri := GetRequestInfoFromHttpHeaders(request.header http.Header)
+res, err := TranslateHttpTraceRequest(requst.body io.Reader, ri RequestInfo)
 
 // OTLP Trace gRPC
 res, err := TranslateGrpcTraceRequest(request *collectorTrace.ExportTraceServiceRequest)
@@ -21,7 +22,7 @@ The library also includes generic ways to extract request information (API Key, 
 
 ```
 // HTTP request
-requestInfo := GetRequestInfoFromHttpHeaders(r *http.Request)
+requestInfo := GetRequestInfoFromHttpHeaders(header http.Header)
 
 // gRPC request context
 requestInfo := GetRequestInfoFromGrpcMetadata(ctx context.Context)

--- a/otlp/README.md
+++ b/otlp/README.md
@@ -9,8 +9,8 @@ You can either provide the OTLP trace request directly or a HTTP request object 
 
 ```
 // HTTP Request
-ri := GetRequestInfoFromHttpHeaders(request.header http.Header)
-res, err := TranslateHttpTraceRequest(requst.body io.Reader, ri RequestInfo)
+ri := GetRequestInfoFromHttpHeaders(request.header) // (request.header http.Header)
+res, err := TranslateHttpTraceRequest(request.body, ri) //(request.body io.Reader, ri RequestInfo)
 
 // OTLP Trace gRPC
 res, err := TranslateGrpcTraceRequest(request *collectorTrace.ExportTraceServiceRequest)
@@ -22,7 +22,7 @@ The library also includes generic ways to extract request information (API Key, 
 
 ```
 // HTTP request
-requestInfo := GetRequestInfoFromHttpHeaders(header http.Header)
+requestInfo := GetRequestInfoFromHttpHeaders(header) // (header http.Header)
 
 // gRPC request context
 requestInfo := GetRequestInfoFromGrpcMetadata(ctx context.Context)

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -29,16 +29,15 @@ type RequestInfo struct {
 	GRPCAcceptEncoding string
 }
 
-func (ri *RequestInfo) HasValidContentType() bool {
-	return ri.ContentType == "application/protobuf" || ri.ContentType == "application/x-protobuf"
-}
-
 func (ri *RequestInfo) ValidateHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
 	if len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
+	}
+	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
+		return ErrInvalidContentType
 	}
 	return nil
 }

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -2,7 +2,7 @@ package otlp
 
 import (
 	"context"
-	"net/http"
+	"strings"
 
 	common "go.opentelemetry.io/proto/otlp/common/v1"
 	"google.golang.org/grpc/metadata"
@@ -57,16 +57,20 @@ func GetRequestInfoFromGrpcMetadata(ctx context.Context) RequestInfo {
 	return ri
 }
 
-func GetRequestInfoFromHttpHeaders(header http.Header) RequestInfo {
+func GetRequestInfoFromHttpHeaders(headers map[string][]string) RequestInfo {
 	return RequestInfo{
-		ApiKey:             header.Get(apiKeyHeader),
-		Dataset:            header.Get(datasetHeader),
-		ProxyToken:         header.Get(proxyTokenHeader),
-		UserAgent:          header.Get(userAgentHeader),
-		ContentType:        header.Get(contentTypeHeader),
-		ContentEncoding:    header.Get(contentEncodingHeader),
-		GRPCAcceptEncoding: header.Get(gRPCAcceptEncodingHeader),
+		ApiKey:             getValue(headers, apiKeyHeader),
+		Dataset:            getValue(headers, datasetHeader),
+		ProxyToken:         getValue(headers, proxyTokenHeader),
+		UserAgent:          getValue(headers, userAgentHeader),
+		ContentType:        getValue(headers, contentTypeHeader),
+		ContentEncoding:    getValue(headers, contentEncodingHeader),
+		GRPCAcceptEncoding: getValue(headers, gRPCAcceptEncodingHeader),
 	}
+}
+
+func getValue(m map[string][]string, key string) string {
+	return strings.Join(m[key], ",")
 }
 
 func getValueFromMetadata(md metadata.MD, key string) string {

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -2,7 +2,7 @@ package otlp
 
 import (
 	"context"
-	"strings"
+	"net/http"
 
 	common "go.opentelemetry.io/proto/otlp/common/v1"
 	"google.golang.org/grpc/metadata"
@@ -57,20 +57,16 @@ func GetRequestInfoFromGrpcMetadata(ctx context.Context) RequestInfo {
 	return ri
 }
 
-func GetRequestInfoFromHttpHeaders(headers map[string][]string) RequestInfo {
+func GetRequestInfoFromHttpHeaders(header http.Header) RequestInfo {
 	return RequestInfo{
-		ApiKey:             getValue(headers, apiKeyHeader),
-		Dataset:            getValue(headers, datasetHeader),
-		ProxyToken:         getValue(headers, proxyTokenHeader),
-		UserAgent:          getValue(headers, userAgentHeader),
-		ContentType:        getValue(headers, contentTypeHeader),
-		ContentEncoding:    getValue(headers, contentEncodingHeader),
-		GRPCAcceptEncoding: getValue(headers, gRPCAcceptEncodingHeader),
+		ApiKey:             header.Get(apiKeyHeader),
+		Dataset:            header.Get(datasetHeader),
+		ProxyToken:         header.Get(proxyTokenHeader),
+		UserAgent:          header.Get(userAgentHeader),
+		ContentType:        header.Get(contentTypeHeader),
+		ContentEncoding:    header.Get(contentEncodingHeader),
+		GRPCAcceptEncoding: header.Get(gRPCAcceptEncodingHeader),
 	}
-}
-
-func getValue(m map[string][]string, key string) string {
-	return strings.Join(m[key], ",")
 }
 
 func getValueFromMetadata(md metadata.MD, key string) string {

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -57,15 +57,15 @@ func GetRequestInfoFromGrpcMetadata(ctx context.Context) RequestInfo {
 	return ri
 }
 
-func GetRequestInfoFromHttpHeaders(r *http.Request) RequestInfo {
+func GetRequestInfoFromHttpHeaders(header http.Header) RequestInfo {
 	return RequestInfo{
-		ApiKey:             r.Header.Get(apiKeyHeader),
-		Dataset:            r.Header.Get(datasetHeader),
-		ProxyToken:         r.Header.Get(proxyTokenHeader),
-		UserAgent:          r.Header.Get(userAgentHeader),
-		ContentType:        r.Header.Get(contentTypeHeader),
-		ContentEncoding:    r.Header.Get(contentEncodingHeader),
-		GRPCAcceptEncoding: r.Header.Get(gRPCAcceptEncodingHeader),
+		ApiKey:             header.Get(apiKeyHeader),
+		Dataset:            header.Get(datasetHeader),
+		ProxyToken:         header.Get(proxyTokenHeader),
+		UserAgent:          header.Get(userAgentHeader),
+		ContentType:        header.Get(contentTypeHeader),
+		ContentEncoding:    header.Get(contentEncodingHeader),
+		GRPCAcceptEncoding: header.Get(gRPCAcceptEncodingHeader),
 	}
 }
 

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -2,7 +2,6 @@ package otlp
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,14 +26,15 @@ func TestParseGrpcMetadataIntoRequestInfo(t *testing.T) {
 }
 
 func TestParseHttpHeadersIntoRequestInfo(t *testing.T) {
-	header := http.Header{}
-	header.Set(apiKeyHeader, "test-api-key")
-	header.Set(datasetHeader, "test-dataset")
-	header.Set(proxyTokenHeader, "test-proxy-token")
-	header.Set(userAgentHeader, "test-user-agent")
-	header.Set(contentTypeHeader, "test-content-type")
+	headers := map[string][]string{
+		apiKeyHeader:      {"test-api-key"},
+		datasetHeader:     {"test-dataset"},
+		proxyTokenHeader:  {"test-proxy-token"},
+		userAgentHeader:   {"test-user-agent"},
+		contentTypeHeader: {"test-content-type"},
+	}
 
-	ri := GetRequestInfoFromHttpHeaders(header)
+	ri := GetRequestInfoFromHttpHeaders(headers)
 	assert.Equal(t, "test-api-key", ri.ApiKey)
 	assert.Equal(t, "test-dataset", ri.Dataset)
 	assert.Equal(t, "test-proxy-token", ri.ProxyToken)

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -2,6 +2,7 @@ package otlp
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,15 +27,14 @@ func TestParseGrpcMetadataIntoRequestInfo(t *testing.T) {
 }
 
 func TestParseHttpHeadersIntoRequestInfo(t *testing.T) {
-	headers := map[string][]string{
-		apiKeyHeader:      {"test-api-key"},
-		datasetHeader:     {"test-dataset"},
-		proxyTokenHeader:  {"test-proxy-token"},
-		userAgentHeader:   {"test-user-agent"},
-		contentTypeHeader: {"test-content-type"},
-	}
+	header := http.Header{}
+	header.Set(apiKeyHeader, "test-api-key")
+	header.Set(datasetHeader, "test-dataset")
+	header.Set(proxyTokenHeader, "test-proxy-token")
+	header.Set(userAgentHeader, "test-user-agent")
+	header.Set(contentTypeHeader, "test-content-type")
 
-	ri := GetRequestInfoFromHttpHeaders(headers)
+	ri := GetRequestInfoFromHttpHeaders(header)
 	assert.Equal(t, "test-api-key", ri.ApiKey)
 	assert.Equal(t, "test-dataset", ri.Dataset)
 	assert.Equal(t, "test-proxy-token", ri.ProxyToken)

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -42,26 +42,6 @@ func TestParseHttpHeadersIntoRequestInfo(t *testing.T) {
 	assert.Equal(t, "test-content-type", ri.ContentType)
 }
 
-func TestHasValidContentType(t *testing.T) {
-	testCases := []struct {
-		contentType string
-		exepcted    bool
-	}{
-		{contentType: "application/protobuf", exepcted: true},
-		{contentType: "application/x-protobuf", exepcted: true},
-		{contentType: "application/json", exepcted: false},
-		{contentType: "application/javascript", exepcted: false},
-		{contentType: "application/xml", exepcted: false},
-		{contentType: "application/octet-stream", exepcted: false},
-		{contentType: "text-plain", exepcted: false},
-	}
-
-	for _, tc := range testCases {
-		ri := RequestInfo{ContentType: tc.contentType}
-		assert.Equal(t, tc.exepcted, ri.HasValidContentType())
-	}
-}
-
 func TestAddAttributesToMap(t *testing.T) {
 	testCases := []struct {
 		key       string
@@ -134,18 +114,26 @@ func TestAddAttributesToMap(t *testing.T) {
 
 func TestValidateHeaders(t *testing.T) {
 	testCases := []struct {
-		apikey  string
-		dataset string
-		err     error
+		apikey      string
+		dataset     string
+		contentType string
+		err         error
 	}{
-		{apikey: "", dataset: "", err: ErrMissingAPIKeyHeader},
-		{apikey: "apikey", dataset: "", err: ErrMissingDatasetHeader},
-		{apikey: "", dataset: "dataset", err: ErrMissingAPIKeyHeader},
-		{apikey: "apikey", dataset: "dataset", err: nil},
+		{apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
+		{apikey: "apikey", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		{apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
+		{apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/json", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
 	}
 
 	for _, tc := range testCases {
-		ri := RequestInfo{ApiKey: tc.apikey, Dataset: tc.dataset}
+		ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
 		err := ri.ValidateHeaders()
 		assert.Equal(t, tc.err, err)
 	}

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -27,14 +27,14 @@ func TestParseGrpcMetadataIntoRequestInfo(t *testing.T) {
 }
 
 func TestParseHttpHeadersIntoRequestInfo(t *testing.T) {
-	r, _ := http.NewRequest("POST", "/", nil)
-	r.Header.Set(apiKeyHeader, "test-api-key")
-	r.Header.Set(datasetHeader, "test-dataset")
-	r.Header.Set(proxyTokenHeader, "test-proxy-token")
-	r.Header.Set(userAgentHeader, "test-user-agent")
-	r.Header.Set(contentTypeHeader, "test-content-type")
+	header := http.Header{}
+	header.Set(apiKeyHeader, "test-api-key")
+	header.Set(datasetHeader, "test-dataset")
+	header.Set(proxyTokenHeader, "test-proxy-token")
+	header.Set(userAgentHeader, "test-user-agent")
+	header.Set(contentTypeHeader, "test-content-type")
 
-	ri := GetRequestInfoFromHttpHeaders(r)
+	ri := GetRequestInfoFromHttpHeaders(header)
 	assert.Equal(t, "test-api-key", ri.ApiKey)
 	assert.Equal(t, "test-dataset", ri.Dataset)
 	assert.Equal(t, "test-proxy-token", ri.ProxyToken)

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -19,14 +18,6 @@ const (
 	traceIDShortLength = 8
 	traceIDLongLength  = 16
 )
-
-func TranslateHttpTraceRequest(req *http.Request) ([]map[string]interface{}, error) {
-	ri := GetRequestInfoFromHttpHeaders(req.Header)
-	if err := ri.ValidateHeaders(); err != nil {
-		return nil, err
-	}
-	return TranslateTraceRequestFromReader(req.Body, ri)
-}
 
 func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) ([]map[string]interface{}, error) {
 	if err := ri.ValidateHeaders(); err != nil {

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -19,7 +19,7 @@ const (
 	traceIDLongLength  = 16
 )
 
-func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) ([]map[string]interface{}, error) {
+func TranslateHttpTraceRequest(body io.ReadCloser, ri RequestInfo) ([]map[string]interface{}, error) {
 	if err := ri.ValidateHeaders(); err != nil {
 		return nil, err
 	}

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -21,11 +21,6 @@ const (
 )
 
 func TranslateHttpTraceRequest(req *http.Request) ([]map[string]interface{}, error) {
-	reqInfo := GetRequestInfoFromHttpHeaders(req)
-	if !reqInfo.HasValidContentType() {
-		return nil, ErrInvalidContentType
-	}
-
 	request, err := parseOTLPBody(req)
 	if err != nil {
 		return nil, ErrFailedParseBody

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -21,11 +21,21 @@ const (
 )
 
 func TranslateHttpTraceRequest(req *http.Request) ([]map[string]interface{}, error) {
-	request, err := parseOTLPBody(req)
+	ri := GetRequestInfoFromHttpHeaders(req.Header)
+	if err := ri.ValidateHeaders(); err != nil {
+		return nil, err
+	}
+	return TranslateTraceRequestFromReader(req.Body, ri)
+}
+
+func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) ([]map[string]interface{}, error) {
+	if err := ri.ValidateHeaders(); err != nil {
+		return nil, err
+	}
+	request, err := parseOTLPBody(body, ri.ContentEncoding)
 	if err != nil {
 		return nil, ErrFailedParseBody
 	}
-
 	return TranslateGrpcTraceRequest(request)
 }
 
@@ -211,16 +221,16 @@ func getSpanStatusCode(status *trace.Status) trace.Status_StatusCode {
 	return status.Code
 }
 
-func parseOTLPBody(r *http.Request) (request *collectorTrace.ExportTraceServiceRequest, err error) {
-	defer r.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+func parseOTLPBody(body io.ReadCloser, contentEncoding string) (request *collectorTrace.ExportTraceServiceRequest, err error) {
+	defer body.Close()
+	bodyBytes, err := ioutil.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader := bytes.NewReader(bodyBytes)
 
 	var reader io.Reader
-	switch r.Header.Get("Content-Encoding") {
+	switch contentEncoding {
 	case "gzip":
 		gzipReader, err := gzip.NewReader(bodyReader)
 		defer gzipReader.Close()

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -202,6 +202,8 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 			}
 
 			request, _ := http.NewRequest("POST", "", io.NopCloser(strings.NewReader(buf.String())))
+			request.Header.Set("x-honeycomb-team", "team")
+			request.Header.Set("x-honeycomb-dataset", "dataset")
 			request.Header.Set("content-type", "application/protobuf")
 			request.Header.Set("content-encoding", encoding)
 
@@ -250,6 +252,8 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 func TestInvalidContentTypeReturnsError(t *testing.T) {
 	body, _ := proto.Marshal(&collectortrace.ExportTraceServiceRequest{})
 	request, _ := http.NewRequest("POST", "", io.NopCloser(bytes.NewReader(body)))
+	request.Header.Set("x-honeycomb-team", "team")
+	request.Header.Set("x-honeycomb-dataset", "dataset")
 	request.Header.Set("content-type", "application/json")
 
 	batch, err := TranslateHttpTraceRequest(request)
@@ -260,6 +264,8 @@ func TestInvalidContentTypeReturnsError(t *testing.T) {
 func TestInvalidBodyReturnsError(t *testing.T) {
 	body := test.RandomBytes(10)
 	request, _ := http.NewRequest("POST", "", io.NopCloser(bytes.NewReader(body)))
+	request.Header.Set("x-honeycomb-team", "team")
+	request.Header.Set("x-honeycomb-dataset", "dataset")
 	request.Header.Set("content-type", "application/protobuf")
 
 	batch, err := TranslateHttpTraceRequest(request)

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -207,7 +207,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 				ContentEncoding: encoding,
 			}
 
-			events, err := TranslateTraceRequestFromReader(io.NopCloser(strings.NewReader(buf.String())), ri)
+			events, err := TranslateHttpTraceRequest(io.NopCloser(strings.NewReader(buf.String())), ri)
 			assert.Nil(t, err)
 			assert.Equal(t, 3, len(events))
 
@@ -257,7 +257,7 @@ func TestInvalidContentTypeReturnsError(t *testing.T) {
 		ContentType: "application/json",
 	}
 
-	batch, err := TranslateTraceRequestFromReader(io.NopCloser(bytes.NewReader(body)), ri)
+	batch, err := TranslateHttpTraceRequest(io.NopCloser(bytes.NewReader(body)), ri)
 	assert.Nil(t, batch)
 	assert.Equal(t, ErrInvalidContentType, err)
 }
@@ -270,7 +270,7 @@ func TestInvalidBodyReturnsError(t *testing.T) {
 		ContentType: "application/protobuf",
 	}
 
-	batch, err := TranslateTraceRequestFromReader(io.NopCloser(bytes.NewReader(body)), ri)
+	batch, err := TranslateHttpTraceRequest(io.NopCloser(bytes.NewReader(body)), ri)
 	assert.Nil(t, batch)
 	assert.Equal(t, ErrFailedParseBody, err)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Updates husky interface to not require http.Request object and offers overloads that take `http.Header` or `io.BodyCloser` objects. This improves compatibility of consumers.

## Short description of the changes
- move validate content type into validate headers
- update `GetRequestInfoFromHttpHeaders` to take `http.Header` instead of `http.Request`
- update `TranslateHttpTraceRequest` to take `io.BodyCloser` and `RequestInfo` instead of `http.Request`