### PR TITLE
Update translate trace request calls to return struct instead of params

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -27,6 +27,7 @@ type TraceResult struct {
 type Event struct {
 	Attributes map[string]interface{}
 	Timestamp  time.Time
+	SampleRate int
 }
 
 func TranslateHttpTraceRequest(body io.ReadCloser, ri RequestInfo) (*TraceResult, error) {
@@ -85,6 +86,15 @@ func TranslateGrpcTraceRequest(request *collectorTrace.ExportTraceServiceRequest
 				}
 				if span.Attributes != nil {
 					addAttributesToMap(eventAttrs, span.Attributes)
+				}
+				var sampleRateKey string
+				if eventAttrs["sampleRate"] != nil {
+					sampleRateKey = "sampleRate"
+				} else if eventAttrs["SampleRate"] != nil {
+					sampleRateKey = "sampleRate"
+				}
+				if sampleRateKey != "" {
+					SampleRateValue := eventAttrs[sampleRateKey]
 				}
 
 				// copy resource attributes to event attributes

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -23,7 +23,7 @@ const (
 	defaultSampleRate  = int32(1)
 )
 
-type TraceResult struct {
+type TranslateTraceRequestResult struct {
 	RequestSize int
 	Events      []Event
 }
@@ -34,7 +34,7 @@ type Event struct {
 	SampleRate int32
 }
 
-func TranslateHttpTraceRequest(body io.ReadCloser, ri RequestInfo) (*TraceResult, error) {
+func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) (*TranslateTraceRequestResult, error) {
 	if err := ri.ValidateHeaders(); err != nil {
 		return nil, err
 	}
@@ -42,10 +42,10 @@ func TranslateHttpTraceRequest(body io.ReadCloser, ri RequestInfo) (*TraceResult
 	if err != nil {
 		return nil, ErrFailedParseBody
 	}
-	return TranslateGrpcTraceRequest(request)
+	return TranslateTraceRequest(request)
 }
 
-func TranslateGrpcTraceRequest(request *collectorTrace.ExportTraceServiceRequest) (*TraceResult, error) {
+func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest) (*TranslateTraceRequestResult, error) {
 	batch := []Event{}
 	for _, resourceSpan := range request.ResourceSpans {
 		resourceAttrs := make(map[string]interface{})
@@ -152,7 +152,7 @@ func TranslateGrpcTraceRequest(request *collectorTrace.ExportTraceServiceRequest
 			}
 		}
 	}
-	return &TraceResult{
+	return &TranslateTraceRequestResult{
 		RequestSize: proto.Size(request),
 		Events:      batch,
 	}, nil

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -82,8 +82,9 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 		}},
 	}
 
-	events, err := TranslateGrpcTraceRequest(req)
+	events, requestSize, err := TranslateGrpcTraceRequest(req)
 	assert.Nil(t, err)
+	assert.Equal(t, proto.Size(req), requestSize)
 	assert.Equal(t, 3, len(events))
 
 	// span
@@ -208,8 +209,9 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 				ContentEncoding: encoding,
 			}
 
-			events, err := TranslateHttpTraceRequest(body, ri)
+			events, requestSize, err := TranslateHttpTraceRequest(body, ri)
 			assert.Nil(t, err)
+			assert.Equal(t, proto.Size(req), requestSize)
 			assert.Equal(t, 3, len(events))
 
 			// span
@@ -259,8 +261,9 @@ func TestInvalidContentTypeReturnsError(t *testing.T) {
 		ContentType: "application/json",
 	}
 
-	batch, err := TranslateHttpTraceRequest(body, ri)
+	batch, requestSize, err := TranslateHttpTraceRequest(body, ri)
 	assert.Nil(t, batch)
+	assert.Equal(t, 0, requestSize)
 	assert.Equal(t, ErrInvalidContentType, err)
 }
 
@@ -273,8 +276,9 @@ func TestInvalidBodyReturnsError(t *testing.T) {
 		ContentType: "application/protobuf",
 	}
 
-	batch, err := TranslateHttpTraceRequest(body, ri)
+	batch, requestSize, err := TranslateHttpTraceRequest(body, ri)
 	assert.Nil(t, batch)
+	assert.Equal(t, 0, requestSize)
 	assert.Equal(t, ErrFailedParseBody, err)
 }
 

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -87,7 +87,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 		}},
 	}
 
-	result, err := TranslateGrpcTraceRequest(req)
+	result, err := TranslateTraceRequest(req)
 	assert.Nil(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
 	assert.Equal(t, 3, len(result.Events))
@@ -216,7 +216,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 				ContentEncoding: encoding,
 			}
 
-			result, err := TranslateHttpTraceRequest(body, ri)
+			result, err := TranslateTraceRequestFromReader(body, ri)
 			assert.Nil(t, err)
 			assert.Equal(t, proto.Size(req), result.RequestSize)
 			assert.Equal(t, 3, len(result.Events))
@@ -267,7 +267,7 @@ func TestInvalidContentTypeReturnsError(t *testing.T) {
 		ContentType: "application/json",
 	}
 
-	result, err := TranslateHttpTraceRequest(body, ri)
+	result, err := TranslateTraceRequestFromReader(body, ri)
 	assert.Nil(t, result)
 	assert.Equal(t, ErrInvalidContentType, err)
 }
@@ -281,7 +281,7 @@ func TestInvalidBodyReturnsError(t *testing.T) {
 		ContentType: "application/protobuf",
 	}
 
-	result, err := TranslateHttpTraceRequest(body, ri)
+	result, err := TranslateTraceRequestFromReader(body, ri)
 	assert.Nil(t, result)
 	assert.Equal(t, ErrFailedParseBody, err)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Update both `TranslateHttpTraceRequest` & `TranslateGrpcTraceRequest` to return a known struct instead of a `map[string]interface{}`. Extend return struct to parse sampleRate attribute and calculate and return trace request size.

- Closes #21 
- Closes #22 

## Short description of the changes
- Add `TranslateTraceRequestResult` and `Event` structs
- Return new structs as part of `TranslateHttpTraceRequest` & `TranslateGrpcTraceRequest` calls
- Extract sampleRate attribute and set on return struct
- Add tests for converting sample rate types, default values, etc
- Gets the request size using `proto.Size(request)` and sets on return struct
- Update tests to ensure the correct size is returned