### PR TITLE
Record number of span events and links

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -71,13 +71,15 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest) (*
 
 				spanKind := getSpanKind(span.Kind)
 				eventAttrs := map[string]interface{}{
-					"trace.trace_id": traceID,
-					"trace.span_id":  spanID,
-					"type":           spanKind,
-					"span.kind":      spanKind,
-					"name":           span.Name,
-					"duration_ms":    float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond),
-					"status_code":    getSpanStatusCode(span.Status),
+					"trace.trace_id":  traceID,
+					"trace.span_id":   spanID,
+					"type":            spanKind,
+					"span.kind":       spanKind,
+					"name":            span.Name,
+					"duration_ms":     float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond),
+					"status_code":     getSpanStatusCode(span.Status),
+					"span.num_links":  len(span.Links),
+					"span.num_events": len(span.Events),
 				}
 				if span.ParentSpanId != nil {
 					eventAttrs["trace.parent_id"] = hex.EncodeToString(span.ParentSpanId)

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -105,6 +105,8 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, trace.Status_STATUS_CODE_OK, ev.Attributes["status_code"])
 	assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+	assert.Equal(t, 1, ev.Attributes["span.num_links"])
+	assert.Equal(t, 1, ev.Attributes["span.num_events"])
 
 	// event
 	ev = result.Events[1]


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Records the number of span events and span links in the parent span as attributes.

## Short description of the changes
- Adds new attributes to record span links and event counts
- Add test to ensure attribute is set

