### PR TITLE
Parse proxy version as part of RequestInfo

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -13,6 +13,7 @@ const (
 	apiKeyHeader             = "x-honeycomb-team"
 	datasetHeader            = "x-honeycomb-dataset"
 	proxyTokenHeader         = "x-honeycomb-proxy-token"
+	proxyVersionHeader       = "x-basenji-version"
 	userAgentHeader          = "user-agent"
 	contentTypeHeader        = "content-type"
 	contentEncodingHeader    = "content-encoding"
@@ -20,9 +21,10 @@ const (
 )
 
 type RequestInfo struct {
-	ApiKey     string
-	Dataset    string
-	ProxyToken string
+	ApiKey       string
+	Dataset      string
+	ProxyToken   string
+	ProxyVersion string
 
 	UserAgent          string
 	ContentType        string
@@ -51,6 +53,7 @@ func GetRequestInfoFromGrpcMetadata(ctx context.Context) RequestInfo {
 		ri.ApiKey = getValueFromMetadata(md, apiKeyHeader)
 		ri.Dataset = getValueFromMetadata(md, datasetHeader)
 		ri.ProxyToken = getValueFromMetadata(md, proxyTokenHeader)
+		ri.ProxyVersion = getValueFromMetadata(md, proxyVersionHeader)
 		ri.UserAgent = getValueFromMetadata(md, userAgentHeader)
 		ri.ContentEncoding = getValueFromMetadata(md, contentEncodingHeader)
 		ri.GRPCAcceptEncoding = getValueFromMetadata(md, gRPCAcceptEncodingHeader)
@@ -63,6 +66,7 @@ func GetRequestInfoFromHttpHeaders(header http.Header) RequestInfo {
 		ApiKey:             header.Get(apiKeyHeader),
 		Dataset:            header.Get(datasetHeader),
 		ProxyToken:         header.Get(proxyTokenHeader),
+		ProxyVersion:       header.Get(proxyVersionHeader),
 		UserAgent:          header.Get(userAgentHeader),
 		ContentType:        header.Get(contentTypeHeader),
 		ContentEncoding:    header.Get(contentEncodingHeader),

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -12,16 +12,18 @@ import (
 
 func TestParseGrpcMetadataIntoRequestInfo(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
-		apiKeyHeader:     "test-api-key",
-		datasetHeader:    "test-dataset",
-		proxyTokenHeader: "test-proxy-token",
-		userAgentHeader:  "test-user-agent",
+		apiKeyHeader:       "test-api-key",
+		datasetHeader:      "test-dataset",
+		proxyTokenHeader:   "test-proxy-token",
+		proxyVersionHeader: "test-proxy-version",
+		userAgentHeader:    "test-user-agent",
 	}))
 	ri := GetRequestInfoFromGrpcMetadata(ctx)
 
 	assert.Equal(t, "test-api-key", ri.ApiKey)
 	assert.Equal(t, "test-dataset", ri.Dataset)
 	assert.Equal(t, "test-proxy-token", ri.ProxyToken)
+	assert.Equal(t, "test-proxy-version", ri.ProxyVersion)
 	assert.Equal(t, "test-user-agent", ri.UserAgent)
 	assert.Equal(t, "application/protobuf", ri.ContentType)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds support for paring and returning the proxy version as part of RequestInfo struct.

- Closes #25 

## Short description of the changes
- Parses the `x-basenji-version` header and sets RequestInfo.ProxyVersion field

