### PR TITLE
Add versioning info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Refinery Changelog
+# Husky Changelog
 
 ## 0.5.0 2021-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Refinery Changelog
 
-## 0.5.0 2021-12-07
+## 0.5.0 2021-12-07
 
 - Parse proxy version as part of RequestInfo (#30)
 - Record number of span events and links (#29)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,7 @@
 # Release Process
 
-1. Add release entry to [changelog](./CHANGELOG.md)
+1. Update [Version.go](version.go) with new version
+2. Add release entry to [changelog](./CHANGELOG.md)
 3. Open a PR with the above, and merge that into main
 4. Create new tag on merged commit with the new version (e.g. `v1.4.1`)
 5. Push the tag upstream (this will kick off the release pipeline in CI)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,5 @@
+package husky
+
+var (
+	Version string = "0.5.0"
+)

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,11 @@
+package husky
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionIsPopulated(t *testing.T) {
+	assert.NotEmpty(t, Version)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds versioning info to easily identify module version at runtime, eg to add to telemetry.

## Short description of the changes
- Adds version.go that holds version number (currently set to latest release `0.5.0`)
- Updates RELEASING doc
- Fix spacing issue in changelog

