### PR TITLE
feat!: environments & services support

### DIFF
--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -123,7 +123,7 @@ func TestAddAttributesToMap(t *testing.T) {
 	}
 }
 
-func TestValidateHeaders(t *testing.T) {
+func TestValidateTracesHeaders(t *testing.T) {
 	testCases := []struct {
 		apikey      string
 		dataset     string
@@ -131,7 +131,8 @@ func TestValidateHeaders(t *testing.T) {
 		err         error
 	}{
 		{apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
-		{apikey: "apikey", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		{apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		{apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
 		{apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
 		{apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
 		{apikey: "apikey", dataset: "dataset", contentType: "application/json", err: ErrInvalidContentType},
@@ -146,6 +147,34 @@ func TestValidateHeaders(t *testing.T) {
 	for _, tc := range testCases {
 		ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
 		err := ri.ValidateTracesHeaders()
+		assert.Equal(t, tc.err, err)
+	}
+}
+
+func TestValidateMetricsHeaders(t *testing.T) {
+	testCases := []struct {
+		apikey      string
+		dataset     string
+		contentType string
+		err         error
+	}{
+		{apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
+		{apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		{apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		{apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
+		{apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/json", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
+	}
+
+	for _, tc := range testCases {
+		ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
+		err := ri.ValidateMetricsHeaders()
 		assert.Equal(t, tc.err, err)
 	}
 }

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -145,7 +145,7 @@ func TestValidateHeaders(t *testing.T) {
 
 	for _, tc := range testCases {
 		ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
-		err := ri.ValidateHeaders()
+		err := ri.ValidateTracesHeaders()
 		assert.Equal(t, tc.err, err)
 	}
 }

--- a/otlp/errors.go
+++ b/otlp/errors.go
@@ -15,10 +15,11 @@ type OTLPError struct {
 }
 
 var (
-	ErrInvalidContentType   = OTLPError{"invalid content-type - only 'application/protobuf' is supported", http.StatusNotImplemented, codes.Unimplemented}
-	ErrFailedParseBody      = OTLPError{"failed to parse OTLP request body", http.StatusBadRequest, codes.Internal}
-	ErrMissingAPIKeyHeader  = OTLPError{"missing 'x-honeycomb-team' header", http.StatusUnauthorized, codes.Unauthenticated}
-	ErrMissingDatasetHeader = OTLPError{"missing 'x-honeycomb-dataset' header", http.StatusUnauthorized, codes.Unauthenticated}
+	ErrInvalidContentType     = OTLPError{"invalid content-type - only 'application/protobuf' is supported", http.StatusNotImplemented, codes.Unimplemented}
+	ErrFailedParseBody        = OTLPError{"failed to parse OTLP request body", http.StatusBadRequest, codes.Internal}
+	ErrMissingAPIKeyHeader    = OTLPError{"missing 'x-honeycomb-team' header", http.StatusUnauthorized, codes.Unauthenticated}
+	ErrMissingDatasetHeader   = OTLPError{"missing 'x-honeycomb-dataset' header", http.StatusUnauthorized, codes.Unauthenticated}
+	ErrMissingServiceNameAttr = OTLPError{"missing service.name attribute", http.StatusBadRequest, codes.InvalidArgument}
 )
 
 func (e OTLPError) Error() string {

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func TestTranslateGrpcTraceRequest(t *testing.T) {
+func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 	traceID := test.RandomBytes(16)
 	spanID := test.RandomBytes(8)
 	startTimestamp := time.Now()
@@ -30,6 +30,12 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	linkedTraceID := test.RandomBytes(16)
 	linkedSpanID := test.RandomBytes(8)
 
+	ri := RequestInfo{
+		ApiKey:      "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
 	req := &collectortrace.ExportTraceServiceRequest{
 		ResourceSpans: []*trace.ResourceSpans{{
 			Resource: &resource.Resource{
@@ -37,6 +43,11 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 					Key: "resource_attr",
 					Value: &common.AnyValue{
 						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
+					},
+				}, {
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service"},
 					},
 				}},
 			},
@@ -87,13 +98,141 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 		}},
 	}
 
-	result, err := TranslateTraceRequest(req)
+	result, err := TranslateTraceRequest(req, ri)
 	assert.Nil(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
-	assert.Equal(t, 3, len(result.Events))
+	assert.Equal(t, 1, len(result.Batches))
+	events := result.Batches["legacy-dataset"]
+	assert.Equal(t, 3, len(events))
 
 	// span
-	ev := result.Events[0]
+	ev := events[0]
+	assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
+	assert.Equal(t, int32(100), ev.SampleRate)
+	assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+	assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.span_id"])
+	assert.Equal(t, "client", ev.Attributes["type"])
+	assert.Equal(t, "client", ev.Attributes["span.kind"])
+	assert.Equal(t, "test_span", ev.Attributes["name"])
+	assert.Equal(t, "my-service", ev.Attributes["service.name"])
+	assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
+	assert.Equal(t, trace.Status_STATUS_CODE_OK, ev.Attributes["status_code"])
+	assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
+	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+	assert.Equal(t, 1, ev.Attributes["span.num_links"])
+	assert.Equal(t, 1, ev.Attributes["span.num_events"])
+
+	// event
+	ev = events[1]
+	assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+	assert.Equal(t, int32(0), ev.SampleRate)
+	assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+	assert.Equal(t, "span_event", ev.Attributes["name"])
+	assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+	assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
+	assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
+	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+
+	// link
+	ev = events[2]
+	assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
+	assert.Equal(t, int32(0), ev.SampleRate)
+	assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+	assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+	assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])
+	assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.Attributes["trace.link.span_id"])
+	assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+	assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
+	assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
+	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+}
+
+func TestTranslateGrpcTraceRequest(t *testing.T) {
+	traceID := test.RandomBytes(16)
+	spanID := test.RandomBytes(8)
+	startTimestamp := time.Now()
+	endTimestamp := startTimestamp.Add(time.Millisecond * 5)
+
+	linkedTraceID := test.RandomBytes(16)
+	linkedSpanID := test.RandomBytes(8)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "resource_attr",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
+					},
+				}, {
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service"},
+					},
+				}},
+			},
+			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+				Spans: []*trace.Span{{
+					TraceId:           traceID,
+					SpanId:            spanID,
+					Name:              "test_span",
+					Kind:              trace.Span_SPAN_KIND_CLIENT,
+					Status:            &trace.Status{Code: trace.Status_STATUS_CODE_OK},
+					StartTimeUnixNano: uint64(startTimestamp.Nanosecond()),
+					EndTimeUnixNano:   uint64(endTimestamp.Nanosecond()),
+					Attributes: []*common.KeyValue{
+						{
+							Key: "span_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
+							},
+						},
+						{
+							Key: "sampleRate",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_IntValue{IntValue: 100},
+							},
+						},
+					},
+					Events: []*trace.Span_Event{{
+						Name: "span_event",
+						Attributes: []*common.KeyValue{{
+							Key: "span_event_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_event_attr_val"},
+							},
+						}},
+					}},
+					Links: []*trace.Span_Link{{
+						TraceId: linkedTraceID,
+						SpanId:  linkedSpanID,
+						Attributes: []*common.KeyValue{{
+							Key: "span_link_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_link_attr_val"},
+							},
+						}},
+					}},
+				}},
+			}},
+		}},
+	}
+
+	result, err := TranslateTraceRequest(req, ri)
+	assert.Nil(t, err)
+	assert.Equal(t, proto.Size(req), result.RequestSize)
+	assert.Equal(t, 1, len(result.Batches))
+	events := result.Batches["my-service"]
+	assert.Equal(t, 3, len(events))
+
+	// span
+	ev := events[0]
 	assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
 	assert.Equal(t, int32(100), ev.SampleRate)
 	assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
@@ -109,7 +248,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, 1, ev.Attributes["span.num_events"])
 
 	// event
-	ev = result.Events[1]
+	ev = events[1]
 	assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
 	assert.Equal(t, int32(0), ev.SampleRate)
 	assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
@@ -120,7 +259,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 
 	// link
-	ev = result.Events[2]
+	ev = events[2]
 	assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
 	assert.Equal(t, int32(0), ev.SampleRate)
 	assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
@@ -133,7 +272,63 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 }
 
-func TestTranslateHttpTraceRequest(t *testing.T) {
+func TestTranslateGrpcTraceRequestFromMultipleServices(t *testing.T) {
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service-a"},
+					},
+				}},
+			},
+			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+				Spans: []*trace.Span{{
+					TraceId: test.RandomBytes(16),
+					SpanId:  test.RandomBytes(8),
+					Name:    "test_span_a",
+				}},
+			}},
+		}, {
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service-b"},
+					},
+				}},
+			},
+			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+				Spans: []*trace.Span{{
+					TraceId: test.RandomBytes(16),
+					SpanId:  test.RandomBytes(8),
+					Name:    "test_span_b",
+				}},
+			}},
+		}},
+	}
+
+	result, err := TranslateTraceRequest(req, ri)
+	assert.Nil(t, err)
+	assert.Equal(t, proto.Size(req), result.RequestSize)
+	assert.Equal(t, 2, len(result.Batches))
+	eventsA := result.Batches["my-service-a"]
+	eventsB := result.Batches["my-service-b"]
+	assert.Equal(t, 1, len(eventsA))
+	assert.Equal(t, 1, len(eventsB))
+
+	assert.Equal(t, "test_span_a", eventsA[0].Attributes["name"])
+	assert.Equal(t, "test_span_b", eventsB[0].Attributes["name"])
+}
+
+func TestTranslateLegacyHttpTraceRequest(t *testing.T) {
 	traceID := test.RandomBytes(16)
 	spanID := test.RandomBytes(8)
 	startTimestamp := time.Now()
@@ -149,6 +344,11 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 					Key: "resource_attr",
 					Value: &common.AnyValue{
 						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
+					},
+				}, {
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service"},
 					},
 				}},
 			},
@@ -212,8 +412,8 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 
 			body := io.NopCloser(strings.NewReader(buf.String()))
 			ri := RequestInfo{
-				ApiKey:          "apikey",
-				Dataset:         "dataset",
+				ApiKey:          "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+				Dataset:         "legacy-dataset",
 				ContentType:     "application/protobuf",
 				ContentEncoding: encoding,
 			}
@@ -221,23 +421,26 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 			result, err := TranslateTraceRequestFromReader(body, ri)
 			assert.Nil(t, err)
 			assert.Equal(t, proto.Size(req), result.RequestSize)
-			assert.Equal(t, 3, len(result.Events))
+			assert.Equal(t, 1, len(result.Batches))
+			events := result.Batches["legacy-dataset"]
+			assert.Equal(t, 3, len(events))
 
 			// span
-			ev := result.Events[0]
+			ev := events[0]
 			assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
 			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
 			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.span_id"])
 			assert.Equal(t, "client", ev.Attributes["type"])
 			assert.Equal(t, "client", ev.Attributes["span.kind"])
 			assert.Equal(t, "test_span", ev.Attributes["name"])
+			assert.Equal(t, "my-service", ev.Attributes["service.name"])
 			assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
 			assert.Equal(t, trace.Status_STATUS_CODE_OK, ev.Attributes["status_code"])
 			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 
 			// event
-			ev = result.Events[1]
+			ev = events[1]
 			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
 			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
 			assert.Equal(t, "span_event", ev.Attributes["name"])
@@ -247,7 +450,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 
 			// link
-			ev = result.Events[2]
+			ev = events[2]
 			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
 			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
 			assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])
@@ -258,6 +461,204 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 		})
 	}
+}
+
+func TestTranslateHttpTraceRequest(t *testing.T) {
+	traceID := test.RandomBytes(16)
+	spanID := test.RandomBytes(8)
+	startTimestamp := time.Now()
+	endTimestamp := startTimestamp.Add(time.Millisecond * 5)
+
+	linkedTraceID := test.RandomBytes(16)
+	linkedSpanID := test.RandomBytes(8)
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "resource_attr",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
+					},
+				}, {
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service"},
+					},
+				}},
+			},
+			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+				Spans: []*trace.Span{{
+					TraceId:           traceID,
+					SpanId:            spanID,
+					Name:              "test_span",
+					Kind:              trace.Span_SPAN_KIND_CLIENT,
+					Status:            &trace.Status{Code: trace.Status_STATUS_CODE_OK},
+					StartTimeUnixNano: uint64(startTimestamp.Nanosecond()),
+					EndTimeUnixNano:   uint64(endTimestamp.Nanosecond()),
+					Attributes: []*common.KeyValue{{
+						Key: "span_attr",
+						Value: &common.AnyValue{
+							Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
+						},
+					}},
+					Events: []*trace.Span_Event{{
+						Name: "span_event",
+						Attributes: []*common.KeyValue{{
+							Key: "span_event_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_event_attr_val"},
+							},
+						}},
+					}},
+					Links: []*trace.Span_Link{{
+						TraceId: linkedTraceID,
+						SpanId:  linkedSpanID,
+						Attributes: []*common.KeyValue{{
+							Key: "span_link_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_link_attr_val"},
+							},
+						}},
+					}},
+				}},
+			}},
+		}},
+	}
+
+	bodyBytes, err := proto.Marshal(req)
+	assert.Nil(t, err)
+
+	for _, encoding := range []string{"", "gzip", "zstd"} {
+		t.Run(encoding, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			switch encoding {
+			case "gzip":
+				w := gzip.NewWriter(buf)
+				w.Write(bodyBytes)
+				w.Close()
+			case "zstd":
+				w, _ := zstd.NewWriter(buf)
+				w.Write(bodyBytes)
+				w.Close()
+			default:
+				buf.Write(bodyBytes)
+			}
+
+			body := io.NopCloser(strings.NewReader(buf.String()))
+			ri := RequestInfo{
+				ApiKey:          "abc123DEF456ghi789jklm",
+				Dataset:         "legacy-dataset",
+				ContentType:     "application/protobuf",
+				ContentEncoding: encoding,
+			}
+
+			result, err := TranslateTraceRequestFromReader(body, ri)
+			assert.Nil(t, err)
+			assert.Equal(t, proto.Size(req), result.RequestSize)
+			assert.Equal(t, 1, len(result.Batches))
+			events := result.Batches["my-service"]
+			assert.Equal(t, 3, len(events))
+
+			// span
+			ev := events[0]
+			assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
+			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.span_id"])
+			assert.Equal(t, "client", ev.Attributes["type"])
+			assert.Equal(t, "client", ev.Attributes["span.kind"])
+			assert.Equal(t, "test_span", ev.Attributes["name"])
+			assert.Equal(t, "my-service", ev.Attributes["service.name"])
+			assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
+			assert.Equal(t, trace.Status_STATUS_CODE_OK, ev.Attributes["status_code"])
+			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
+			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+
+			// event
+			ev = events[1]
+			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+			assert.Equal(t, "span_event", ev.Attributes["name"])
+			assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+			assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
+			assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
+			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+
+			// link
+			ev = events[2]
+			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+			assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])
+			assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.Attributes["trace.link.span_id"])
+			assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+			assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
+			assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
+			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+		})
+	}
+}
+
+func TestTranslateHttpTraceRequestFromMultipleServices(t *testing.T) {
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service-a"},
+					},
+				}},
+			},
+			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+				Spans: []*trace.Span{{
+					TraceId: test.RandomBytes(16),
+					SpanId:  test.RandomBytes(8),
+					Name:    "test_span_a",
+				}},
+			}},
+		}, {
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service-b"},
+					},
+				}},
+			},
+			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+				Spans: []*trace.Span{{
+					TraceId: test.RandomBytes(16),
+					SpanId:  test.RandomBytes(8),
+					Name:    "test_span_b",
+				}},
+			}},
+		}},
+	}
+
+	bodyBytes, err := proto.Marshal(req)
+	assert.Nil(t, err)
+
+	buf := new(bytes.Buffer)
+	buf.Write(bodyBytes)
+
+	body := io.NopCloser(strings.NewReader(buf.String()))
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := TranslateTraceRequestFromReader(body, ri)
+	assert.Nil(t, err)
+	assert.Equal(t, proto.Size(req), result.RequestSize)
+	assert.Equal(t, 2, len(result.Batches))
+	eventsA := result.Batches["my-service-a"]
+	eventsB := result.Batches["my-service-b"]
+	assert.Equal(t, 1, len(eventsA))
+	assert.Equal(t, 1, len(eventsB))
+
+	assert.Equal(t, "test_span_a", eventsA[0].Attributes["name"])
+	assert.Equal(t, "test_span_b", eventsB[0].Attributes["name"])
 }
 
 func TestInvalidContentTypeReturnsError(t *testing.T) {
@@ -351,4 +752,74 @@ func TestGetSampleRateConversions(t *testing.T) {
 		assert.Equal(t, tc.expected, getSampleRate(attrs))
 		assert.Equal(t, 0, len(attrs))
 	}
+}
+
+func TestMissingServiceNameAttributeReturnsError(t *testing.T) {
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "my-attribute",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "hello"},
+					},
+				}},
+			},
+			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+				Spans: []*trace.Span{{
+					TraceId: test.RandomBytes(16),
+					SpanId:  test.RandomBytes(8),
+					Name:    "test_span_a",
+				}},
+			}},
+		}},
+	}
+
+	bodyBytes, err := proto.Marshal(req)
+	assert.Nil(t, err)
+
+	buf := new(bytes.Buffer)
+	buf.Write(bodyBytes)
+
+	body := io.NopCloser(strings.NewReader(buf.String()))
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := TranslateTraceRequestFromReader(body, ri)
+	assert.Nil(t, result)
+	assert.Equal(t, ErrMissingServiceNameAttr, err)
+}
+
+func TestMissingServiceNameResourceReturnsError(t *testing.T) {
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+				Spans: []*trace.Span{{
+					TraceId: test.RandomBytes(16),
+					SpanId:  test.RandomBytes(8),
+					Name:    "test_span_a",
+				}},
+			}},
+		}},
+	}
+
+	bodyBytes, err := proto.Marshal(req)
+	assert.Nil(t, err)
+
+	buf := new(bytes.Buffer)
+	buf.Write(bodyBytes)
+
+	body := io.NopCloser(strings.NewReader(buf.String()))
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := TranslateTraceRequestFromReader(body, ri)
+	assert.Nil(t, result)
+	assert.Equal(t, ErrMissingServiceNameAttr, err)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- support environment-aware OTLP instrumentation
- updates https://github.com/honeycombio/telemetry-team/issues/173

## Short description of the changes

- breaking changes!
- ~~ValidateHeaders~~ >> ValidateTracesHeaders, ValidateMetricsHeaders
- TranslateTraceRequest will now return a map of dataset:[events], and will decide if the dataset should come form the metadata/header (legacy) or the service.name attribute

