### PR TITLE
feat!: include individual batch sizes

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -1,155 +1,155 @@
 package otlp
 
 import (
-    "context"
-    "encoding/json"
-    "net/http"
-    "regexp"
+	"context"
+	"encoding/json"
+	"net/http"
+	"regexp"
 
-    common "go.opentelemetry.io/proto/otlp/common/v1"
-    "google.golang.org/grpc/metadata"
+	common "go.opentelemetry.io/proto/otlp/common/v1"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
-    apiKeyHeader             = "x-honeycomb-team"
-    datasetHeader            = "x-honeycomb-dataset"
-    proxyTokenHeader         = "x-honeycomb-proxy-token"
-    proxyVersionHeader       = "x-basenji-version"
-    userAgentHeader          = "user-agent"
-    contentTypeHeader        = "content-type"
-    contentEncodingHeader    = "content-encoding"
-    gRPCAcceptEncodingHeader = "grpc-accept-encoding"
+	apiKeyHeader             = "x-honeycomb-team"
+	datasetHeader            = "x-honeycomb-dataset"
+	proxyTokenHeader         = "x-honeycomb-proxy-token"
+	proxyVersionHeader       = "x-basenji-version"
+	userAgentHeader          = "user-agent"
+	contentTypeHeader        = "content-type"
+	contentEncodingHeader    = "content-encoding"
+	gRPCAcceptEncodingHeader = "grpc-accept-encoding"
 )
 
 var legacyApiKeyPattern = regexp.MustCompile("^[0-9a-f]{32}$")
 
 // RequestInfo represents information parsed from either HTTP headers or gRPC metadata
 type RequestInfo struct {
-    ApiKey       string
-    Dataset      string
-    ProxyToken   string
-    ProxyVersion string
+	ApiKey       string
+	Dataset      string
+	ProxyToken   string
+	ProxyVersion string
 
-    UserAgent          string
-    ContentType        string
-    ContentEncoding    string
-    GRPCAcceptEncoding string
+	UserAgent          string
+	ContentType        string
+	ContentEncoding    string
+	GRPCAcceptEncoding string
 }
 
 // ValidateTracesHeaders validates required headers/metadata for a trace OTLP request
 func (ri *RequestInfo) ValidateTracesHeaders() error {
-    if len(ri.ApiKey) == 0 {
-        return ErrMissingAPIKeyHeader
-    }
-    if isLegacy(ri.ApiKey) && len(ri.Dataset) == 0 {
-        return ErrMissingDatasetHeader
-    }
-    if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
-        return ErrInvalidContentType
-    }
-    return nil
+	if len(ri.ApiKey) == 0 {
+		return ErrMissingAPIKeyHeader
+	}
+	if isLegacy(ri.ApiKey) && len(ri.Dataset) == 0 {
+		return ErrMissingDatasetHeader
+	}
+	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
+		return ErrInvalidContentType
+	}
+	return nil
 }
 
 // ValidateMetricsHeaders validates required headers/metadata for a metric OTLP request
 func (ri *RequestInfo) ValidateMetricsHeaders() error {
-    if len(ri.ApiKey) == 0 {
-        return ErrMissingAPIKeyHeader
-    }
-    if len(ri.Dataset) == 0 {
-        return ErrMissingDatasetHeader
-    }
-    if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
-        return ErrInvalidContentType
-    }
-    return nil
+	if len(ri.ApiKey) == 0 {
+		return ErrMissingAPIKeyHeader
+	}
+	if len(ri.Dataset) == 0 {
+		return ErrMissingDatasetHeader
+	}
+	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
+		return ErrInvalidContentType
+	}
+	return nil
 }
 
 // GetRequestInfoFromGrpcMetadata parses relevant gRPC metadata from an incoming request context
 func GetRequestInfoFromGrpcMetadata(ctx context.Context) RequestInfo {
-    ri := RequestInfo{
-        ContentType: "application/protobuf",
-    }
-    if md, ok := metadata.FromIncomingContext(ctx); ok {
-        ri.ApiKey = getValueFromMetadata(md, apiKeyHeader)
-        ri.Dataset = getValueFromMetadata(md, datasetHeader)
-        ri.ProxyToken = getValueFromMetadata(md, proxyTokenHeader)
-        ri.ProxyVersion = getValueFromMetadata(md, proxyVersionHeader)
-        ri.UserAgent = getValueFromMetadata(md, userAgentHeader)
-        ri.ContentEncoding = getValueFromMetadata(md, contentEncodingHeader)
-        ri.GRPCAcceptEncoding = getValueFromMetadata(md, gRPCAcceptEncodingHeader)
-    }
-    return ri
+	ri := RequestInfo{
+		ContentType: "application/protobuf",
+	}
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		ri.ApiKey = getValueFromMetadata(md, apiKeyHeader)
+		ri.Dataset = getValueFromMetadata(md, datasetHeader)
+		ri.ProxyToken = getValueFromMetadata(md, proxyTokenHeader)
+		ri.ProxyVersion = getValueFromMetadata(md, proxyVersionHeader)
+		ri.UserAgent = getValueFromMetadata(md, userAgentHeader)
+		ri.ContentEncoding = getValueFromMetadata(md, contentEncodingHeader)
+		ri.GRPCAcceptEncoding = getValueFromMetadata(md, gRPCAcceptEncodingHeader)
+	}
+	return ri
 }
 
 // GetRequestInfoFromHttpHeaders parses relevant incoming HTTP headers
 func GetRequestInfoFromHttpHeaders(header http.Header) RequestInfo {
-    return RequestInfo{
-        ApiKey:             header.Get(apiKeyHeader),
-        Dataset:            header.Get(datasetHeader),
-        ProxyToken:         header.Get(proxyTokenHeader),
-        ProxyVersion:       header.Get(proxyVersionHeader),
-        UserAgent:          header.Get(userAgentHeader),
-        ContentType:        header.Get(contentTypeHeader),
-        ContentEncoding:    header.Get(contentEncodingHeader),
-        GRPCAcceptEncoding: header.Get(gRPCAcceptEncodingHeader),
-    }
+	return RequestInfo{
+		ApiKey:             header.Get(apiKeyHeader),
+		Dataset:            header.Get(datasetHeader),
+		ProxyToken:         header.Get(proxyTokenHeader),
+		ProxyVersion:       header.Get(proxyVersionHeader),
+		UserAgent:          header.Get(userAgentHeader),
+		ContentType:        header.Get(contentTypeHeader),
+		ContentEncoding:    header.Get(contentEncodingHeader),
+		GRPCAcceptEncoding: header.Get(gRPCAcceptEncodingHeader),
+	}
 }
 
 func getValueFromMetadata(md metadata.MD, key string) string {
-    if vals := md.Get(key); len(vals) > 0 {
-        return vals[0]
-    }
-    return ""
+	if vals := md.Get(key); len(vals) > 0 {
+		return vals[0]
+	}
+	return ""
 }
 
 func addAttributesToMap(attrs map[string]interface{}, attributes []*common.KeyValue) {
-    for _, attr := range attributes {
-        // ignore entries if the key is empty or value is nil
-        if attr.Key == "" || attr.Value == nil {
-            continue
-        }
-        if val := getValue(attr.Value); val != nil {
-            attrs[attr.Key] = val
-        }
-    }
+	for _, attr := range attributes {
+		// ignore entries if the key is empty or value is nil
+		if attr.Key == "" || attr.Value == nil {
+			continue
+		}
+		if val := getValue(attr.Value); val != nil {
+			attrs[attr.Key] = val
+		}
+	}
 }
 
 func getValue(value *common.AnyValue) interface{} {
-    switch value.Value.(type) {
-    case *common.AnyValue_StringValue:
-        return value.GetStringValue()
-    case *common.AnyValue_BoolValue:
-        return value.GetBoolValue()
-    case *common.AnyValue_DoubleValue:
-        return value.GetDoubleValue()
-    case *common.AnyValue_IntValue:
-        return value.GetIntValue()
-    case *common.AnyValue_ArrayValue:
-        items := value.GetArrayValue().Values
-        arr := make([]interface{}, len(items))
-        for i := 0; i < len(items); i++ {
-            arr[i] = getValue(items[i])
-        }
-        bytes, err := json.Marshal(arr)
-        if err == nil {
-            return string(bytes)
-        }
-    case *common.AnyValue_KvlistValue:
-        items := value.GetKvlistValue().Values
-        arr := make([]map[string]interface{}, len(items))
-        for i := 0; i < len(items); i++ {
-            arr[i] = map[string]interface{}{
-                items[i].Key: getValue(items[i].Value),
-            }
-        }
-        bytes, err := json.Marshal(arr)
-        if err == nil {
-            return string(bytes)
-        }
-    }
-    return nil
+	switch value.Value.(type) {
+	case *common.AnyValue_StringValue:
+		return value.GetStringValue()
+	case *common.AnyValue_BoolValue:
+		return value.GetBoolValue()
+	case *common.AnyValue_DoubleValue:
+		return value.GetDoubleValue()
+	case *common.AnyValue_IntValue:
+		return value.GetIntValue()
+	case *common.AnyValue_ArrayValue:
+		items := value.GetArrayValue().Values
+		arr := make([]interface{}, len(items))
+		for i := 0; i < len(items); i++ {
+			arr[i] = getValue(items[i])
+		}
+		bytes, err := json.Marshal(arr)
+		if err == nil {
+			return string(bytes)
+		}
+	case *common.AnyValue_KvlistValue:
+		items := value.GetKvlistValue().Values
+		arr := make([]map[string]interface{}, len(items))
+		for i := 0; i < len(items); i++ {
+			arr[i] = map[string]interface{}{
+				items[i].Key: getValue(items[i].Value),
+			}
+		}
+		bytes, err := json.Marshal(arr)
+		if err == nil {
+			return string(bytes)
+		}
+	}
+	return nil
 }
 
 func isLegacy(apiKey string) bool {
-    return legacyApiKeyPattern.MatchString(apiKey)
+	return legacyApiKeyPattern.MatchString(apiKey)
 }

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -1,150 +1,155 @@
 package otlp
 
 import (
-	"context"
-	"encoding/json"
-	"net/http"
-	"regexp"
+    "context"
+    "encoding/json"
+    "net/http"
+    "regexp"
 
-	common "go.opentelemetry.io/proto/otlp/common/v1"
-	"google.golang.org/grpc/metadata"
+    common "go.opentelemetry.io/proto/otlp/common/v1"
+    "google.golang.org/grpc/metadata"
 )
 
 const (
-	apiKeyHeader             = "x-honeycomb-team"
-	datasetHeader            = "x-honeycomb-dataset"
-	proxyTokenHeader         = "x-honeycomb-proxy-token"
-	proxyVersionHeader       = "x-basenji-version"
-	userAgentHeader          = "user-agent"
-	contentTypeHeader        = "content-type"
-	contentEncodingHeader    = "content-encoding"
-	gRPCAcceptEncodingHeader = "grpc-accept-encoding"
+    apiKeyHeader             = "x-honeycomb-team"
+    datasetHeader            = "x-honeycomb-dataset"
+    proxyTokenHeader         = "x-honeycomb-proxy-token"
+    proxyVersionHeader       = "x-basenji-version"
+    userAgentHeader          = "user-agent"
+    contentTypeHeader        = "content-type"
+    contentEncodingHeader    = "content-encoding"
+    gRPCAcceptEncodingHeader = "grpc-accept-encoding"
 )
 
 var legacyApiKeyPattern = regexp.MustCompile("^[0-9a-f]{32}$")
 
+// RequestInfo represents information parsed from either HTTP headers or gRPC metadata
 type RequestInfo struct {
-	ApiKey       string
-	Dataset      string
-	ProxyToken   string
-	ProxyVersion string
+    ApiKey       string
+    Dataset      string
+    ProxyToken   string
+    ProxyVersion string
 
-	UserAgent          string
-	ContentType        string
-	ContentEncoding    string
-	GRPCAcceptEncoding string
+    UserAgent          string
+    ContentType        string
+    ContentEncoding    string
+    GRPCAcceptEncoding string
 }
 
+// ValidateTracesHeaders validates required headers/metadata for a trace OTLP request
 func (ri *RequestInfo) ValidateTracesHeaders() error {
-	if len(ri.ApiKey) == 0 {
-		return ErrMissingAPIKeyHeader
-	}
-	if isLegacy(ri.ApiKey) && len(ri.Dataset) == 0 {
-		return ErrMissingDatasetHeader
-	}
-	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
-		return ErrInvalidContentType
-	}
-	return nil
+    if len(ri.ApiKey) == 0 {
+        return ErrMissingAPIKeyHeader
+    }
+    if isLegacy(ri.ApiKey) && len(ri.Dataset) == 0 {
+        return ErrMissingDatasetHeader
+    }
+    if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
+        return ErrInvalidContentType
+    }
+    return nil
 }
 
+// ValidateMetricsHeaders validates required headers/metadata for a metric OTLP request
 func (ri *RequestInfo) ValidateMetricsHeaders() error {
-	if len(ri.ApiKey) == 0 {
-		return ErrMissingAPIKeyHeader
-	}
-	if len(ri.Dataset) == 0 {
-		return ErrMissingDatasetHeader
-	}
-	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
-		return ErrInvalidContentType
-	}
-	return nil
+    if len(ri.ApiKey) == 0 {
+        return ErrMissingAPIKeyHeader
+    }
+    if len(ri.Dataset) == 0 {
+        return ErrMissingDatasetHeader
+    }
+    if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
+        return ErrInvalidContentType
+    }
+    return nil
 }
 
+// GetRequestInfoFromGrpcMetadata parses relevant gRPC metadata from an incoming request context
 func GetRequestInfoFromGrpcMetadata(ctx context.Context) RequestInfo {
-	ri := RequestInfo{
-		ContentType: "application/protobuf",
-	}
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		ri.ApiKey = getValueFromMetadata(md, apiKeyHeader)
-		ri.Dataset = getValueFromMetadata(md, datasetHeader)
-		ri.ProxyToken = getValueFromMetadata(md, proxyTokenHeader)
-		ri.ProxyVersion = getValueFromMetadata(md, proxyVersionHeader)
-		ri.UserAgent = getValueFromMetadata(md, userAgentHeader)
-		ri.ContentEncoding = getValueFromMetadata(md, contentEncodingHeader)
-		ri.GRPCAcceptEncoding = getValueFromMetadata(md, gRPCAcceptEncodingHeader)
-	}
-	return ri
+    ri := RequestInfo{
+        ContentType: "application/protobuf",
+    }
+    if md, ok := metadata.FromIncomingContext(ctx); ok {
+        ri.ApiKey = getValueFromMetadata(md, apiKeyHeader)
+        ri.Dataset = getValueFromMetadata(md, datasetHeader)
+        ri.ProxyToken = getValueFromMetadata(md, proxyTokenHeader)
+        ri.ProxyVersion = getValueFromMetadata(md, proxyVersionHeader)
+        ri.UserAgent = getValueFromMetadata(md, userAgentHeader)
+        ri.ContentEncoding = getValueFromMetadata(md, contentEncodingHeader)
+        ri.GRPCAcceptEncoding = getValueFromMetadata(md, gRPCAcceptEncodingHeader)
+    }
+    return ri
 }
 
+// GetRequestInfoFromHttpHeaders parses relevant incoming HTTP headers
 func GetRequestInfoFromHttpHeaders(header http.Header) RequestInfo {
-	return RequestInfo{
-		ApiKey:             header.Get(apiKeyHeader),
-		Dataset:            header.Get(datasetHeader),
-		ProxyToken:         header.Get(proxyTokenHeader),
-		ProxyVersion:       header.Get(proxyVersionHeader),
-		UserAgent:          header.Get(userAgentHeader),
-		ContentType:        header.Get(contentTypeHeader),
-		ContentEncoding:    header.Get(contentEncodingHeader),
-		GRPCAcceptEncoding: header.Get(gRPCAcceptEncodingHeader),
-	}
+    return RequestInfo{
+        ApiKey:             header.Get(apiKeyHeader),
+        Dataset:            header.Get(datasetHeader),
+        ProxyToken:         header.Get(proxyTokenHeader),
+        ProxyVersion:       header.Get(proxyVersionHeader),
+        UserAgent:          header.Get(userAgentHeader),
+        ContentType:        header.Get(contentTypeHeader),
+        ContentEncoding:    header.Get(contentEncodingHeader),
+        GRPCAcceptEncoding: header.Get(gRPCAcceptEncodingHeader),
+    }
 }
 
 func getValueFromMetadata(md metadata.MD, key string) string {
-	if vals := md.Get(key); len(vals) > 0 {
-		return vals[0]
-	}
-	return ""
+    if vals := md.Get(key); len(vals) > 0 {
+        return vals[0]
+    }
+    return ""
 }
 
 func addAttributesToMap(attrs map[string]interface{}, attributes []*common.KeyValue) {
-	for _, attr := range attributes {
-		// ignore entries if the key is empty or value is nil
-		if attr.Key == "" || attr.Value == nil {
-			continue
-		}
-		if val := getValue(attr.Value); val != nil {
-			attrs[attr.Key] = val
-		}
-	}
+    for _, attr := range attributes {
+        // ignore entries if the key is empty or value is nil
+        if attr.Key == "" || attr.Value == nil {
+            continue
+        }
+        if val := getValue(attr.Value); val != nil {
+            attrs[attr.Key] = val
+        }
+    }
 }
 
 func getValue(value *common.AnyValue) interface{} {
-	switch value.Value.(type) {
-	case *common.AnyValue_StringValue:
-		return value.GetStringValue()
-	case *common.AnyValue_BoolValue:
-		return value.GetBoolValue()
-	case *common.AnyValue_DoubleValue:
-		return value.GetDoubleValue()
-	case *common.AnyValue_IntValue:
-		return value.GetIntValue()
-	case *common.AnyValue_ArrayValue:
-		items := value.GetArrayValue().Values
-		arr := make([]interface{}, len(items))
-		for i := 0; i < len(items); i++ {
-			arr[i] = getValue(items[i])
-		}
-		bytes, err := json.Marshal(arr)
-		if err == nil {
-			return string(bytes)
-		}
-	case *common.AnyValue_KvlistValue:
-		items := value.GetKvlistValue().Values
-		arr := make([]map[string]interface{}, len(items))
-		for i := 0; i < len(items); i++ {
-			arr[i] = map[string]interface{}{
-				items[i].Key: getValue(items[i].Value),
-			}
-		}
-		bytes, err := json.Marshal(arr)
-		if err == nil {
-			return string(bytes)
-		}
-	}
-	return nil
+    switch value.Value.(type) {
+    case *common.AnyValue_StringValue:
+        return value.GetStringValue()
+    case *common.AnyValue_BoolValue:
+        return value.GetBoolValue()
+    case *common.AnyValue_DoubleValue:
+        return value.GetDoubleValue()
+    case *common.AnyValue_IntValue:
+        return value.GetIntValue()
+    case *common.AnyValue_ArrayValue:
+        items := value.GetArrayValue().Values
+        arr := make([]interface{}, len(items))
+        for i := 0; i < len(items); i++ {
+            arr[i] = getValue(items[i])
+        }
+        bytes, err := json.Marshal(arr)
+        if err == nil {
+            return string(bytes)
+        }
+    case *common.AnyValue_KvlistValue:
+        items := value.GetKvlistValue().Values
+        arr := make([]map[string]interface{}, len(items))
+        for i := 0; i < len(items); i++ {
+            arr[i] = map[string]interface{}{
+                items[i].Key: getValue(items[i].Value),
+            }
+        }
+        bytes, err := json.Marshal(arr)
+        if err == nil {
+            return string(bytes)
+        }
+    }
+    return nil
 }
 
 func isLegacy(apiKey string) bool {
-	return legacyApiKeyPattern.MatchString(apiKey)
+    return legacyApiKeyPattern.MatchString(apiKey)
 }

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -23,23 +23,31 @@ const (
 	defaultSampleRate  = int32(1)
 )
 
+// TranslateTraceRequestResult represents an OTLP trace request translated into Honeycomb-friendly structure
+// RequestSize is total byte size of the entire OTLP request
+// Batches represent events grouped by their target dataset
 type TranslateTraceRequestResult struct {
 	RequestSize int
 	Batches     []Batch
 }
 
+// Batch represents Honeycomb events grouped by their target dataset
+// SizeBytes is the total byte size of the OTLP structure that represents this batch
 type Batch struct {
 	Dataset   string
 	SizeBytes int
 	Events    []Event
 }
 
+// Event represents a single Honeycomb event
 type Event struct {
 	Attributes map[string]interface{}
 	Timestamp  time.Time
 	SampleRate int32
 }
 
+// TranslateTraceRequestFromReader translates an OTLP/HTTP request into Honeycomb-friendly structure
+// RequestInfo is the parsed information from the HTTP headers
 func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) (*TranslateTraceRequestResult, error) {
 	if err := ri.ValidateTracesHeaders(); err != nil {
 		return nil, err
@@ -51,6 +59,8 @@ func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) (*Trans
 	return TranslateTraceRequest(request, ri)
 }
 
+// TranslateTraceRequest translates an OTLP/gRPC request into Honeycomb-friendly structure
+// RequestInfo is the parsed information from the gRPC metadata
 func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri RequestInfo) (*TranslateTraceRequestResult, error) {
 	if err := ri.ValidateTracesHeaders(); err != nil {
 		return nil, err

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -102,7 +102,10 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
 	assert.Equal(t, 1, len(result.Batches))
-	events := result.Batches["legacy-dataset"]
+	batch := result.Batches[0]
+	assert.Equal(t, "legacy-dataset", batch.Dataset)
+	assert.Equal(t, proto.Size(req.ResourceSpans[0]), batch.SizeBytes)
+	events := batch.Events
 	assert.Equal(t, 3, len(events))
 
 	// span
@@ -228,7 +231,10 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
 	assert.Equal(t, 1, len(result.Batches))
-	events := result.Batches["my-service"]
+	batch := result.Batches[0]
+	assert.Equal(t, "my-service", batch.Dataset)
+	assert.Equal(t, proto.Size(req.ResourceSpans[0]), batch.SizeBytes)
+	events := batch.Events
 	assert.Equal(t, 3, len(events))
 
 	// span
@@ -319,8 +325,14 @@ func TestTranslateGrpcTraceRequestFromMultipleServices(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
 	assert.Equal(t, 2, len(result.Batches))
-	eventsA := result.Batches["my-service-a"]
-	eventsB := result.Batches["my-service-b"]
+	batchA := result.Batches[0]
+	batchB := result.Batches[1]
+	assert.Equal(t, "my-service-a", batchA.Dataset)
+	assert.Equal(t, "my-service-b", batchB.Dataset)
+	assert.Equal(t, proto.Size(req.ResourceSpans[0]), batchA.SizeBytes)
+	assert.Equal(t, proto.Size(req.ResourceSpans[1]), batchB.SizeBytes)
+	eventsA := batchA.Events
+	eventsB := batchB.Events
 	assert.Equal(t, 1, len(eventsA))
 	assert.Equal(t, 1, len(eventsB))
 
@@ -422,7 +434,10 @@ func TestTranslateLegacyHttpTraceRequest(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, proto.Size(req), result.RequestSize)
 			assert.Equal(t, 1, len(result.Batches))
-			events := result.Batches["legacy-dataset"]
+			batch := result.Batches[0]
+			assert.Equal(t, "legacy-dataset", batch.Dataset)
+			assert.Equal(t, proto.Size(req.ResourceSpans[0]), batch.SizeBytes)
+			events := batch.Events
 			assert.Equal(t, 3, len(events))
 
 			// span
@@ -557,7 +572,10 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, proto.Size(req), result.RequestSize)
 			assert.Equal(t, 1, len(result.Batches))
-			events := result.Batches["my-service"]
+			batch := result.Batches[0]
+			assert.Equal(t, "my-service", batch.Dataset)
+			assert.Equal(t, proto.Size(req.ResourceSpans[0]), batch.SizeBytes)
+			events := batch.Events
 			assert.Equal(t, 3, len(events))
 
 			// span
@@ -652,8 +670,15 @@ func TestTranslateHttpTraceRequestFromMultipleServices(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
 	assert.Equal(t, 2, len(result.Batches))
-	eventsA := result.Batches["my-service-a"]
-	eventsB := result.Batches["my-service-b"]
+
+	batchA := result.Batches[0]
+	batchB := result.Batches[1]
+	assert.Equal(t, "my-service-a", batchA.Dataset)
+	assert.Equal(t, "my-service-b", batchB.Dataset)
+	assert.Equal(t, proto.Size(req.ResourceSpans[0]), batchA.SizeBytes)
+	assert.Equal(t, proto.Size(req.ResourceSpans[1]), batchB.SizeBytes)
+	eventsA := batchA.Events
+	eventsB := batchB.Events
 	assert.Equal(t, 1, len(eventsA))
 	assert.Equal(t, 1, len(eventsB))
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- shepherd needs to track how big each request is per dataset
- https://houndsh.slack.com/archives/C015UD6R8PJ/p1643848568491229

## Short description of the changes

- approximating each dataset batch size to be `proto.Size(resourceSpan)`
- previously, `proto.Size(otlpRequest)` would be used in the same stat for the single dataset in the header

