### PR TITLE
maint: remove indent style from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,6 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- editorconfig indent style conflicts with `go fmt` standard (tabs)

## Short description of the changes

- defer to go fmt (which formats with tabs)

