### PR TITLE
empty or missing service name should default to unknown_service

### DIFF
--- a/otlp/errors.go
+++ b/otlp/errors.go
@@ -15,11 +15,10 @@ type OTLPError struct {
 }
 
 var (
-	ErrInvalidContentType     = OTLPError{"invalid content-type - only 'application/protobuf' is supported", http.StatusNotImplemented, codes.Unimplemented}
-	ErrFailedParseBody        = OTLPError{"failed to parse OTLP request body", http.StatusBadRequest, codes.Internal}
-	ErrMissingAPIKeyHeader    = OTLPError{"missing 'x-honeycomb-team' header", http.StatusUnauthorized, codes.Unauthenticated}
-	ErrMissingDatasetHeader   = OTLPError{"missing 'x-honeycomb-dataset' header", http.StatusUnauthorized, codes.Unauthenticated}
-	ErrMissingServiceNameAttr = OTLPError{"missing service.name attribute", http.StatusBadRequest, codes.InvalidArgument}
+	ErrInvalidContentType   = OTLPError{"invalid content-type - only 'application/protobuf' is supported", http.StatusNotImplemented, codes.Unimplemented}
+	ErrFailedParseBody      = OTLPError{"failed to parse OTLP request body", http.StatusBadRequest, codes.Internal}
+	ErrMissingAPIKeyHeader  = OTLPError{"missing 'x-honeycomb-team' header", http.StatusUnauthorized, codes.Unauthenticated}
+	ErrMissingDatasetHeader = OTLPError{"missing 'x-honeycomb-dataset' header", http.StatusUnauthorized, codes.Unauthenticated}
 )
 
 func (e OTLPError) Error() string {

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -21,6 +21,7 @@ const (
 	traceIDLongLength  = 16
 	zeroSampleRate     = int32(0)
 	defaultSampleRate  = int32(1)
+	defaultServiceName = "unknown_service"
 )
 
 // TranslateTraceRequestResult represents an OTLP trace request translated into Honeycomb-friendly structure
@@ -80,11 +81,11 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 			dataset = ri.Dataset
 		} else {
 			if resourceSpan.Resource == nil {
-				return nil, ErrMissingServiceNameAttr
+				dataset = defaultServiceName
 			} else {
 				serviceName, ok := resourceAttrs["service.name"].(string)
 				if !ok || serviceName == "" {
-					return nil, ErrMissingServiceNameAttr
+					dataset = defaultServiceName
 				} else {
 					dataset = serviceName
 				}

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -83,7 +83,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 				return nil, ErrMissingServiceNameAttr
 			} else {
 				serviceName, ok := resourceAttrs["service.name"].(string)
-				if !ok {
+				if !ok || serviceName == "" {
 					return nil, ErrMissingServiceNameAttr
 				} else {
 					dataset = serviceName

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -848,3 +848,42 @@ func TestMissingServiceNameResourceReturnsError(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Equal(t, ErrMissingServiceNameAttr, err)
 }
+
+func TestEmptyServiceNameResourceReturnsError(t *testing.T) {
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: ""},
+					},
+				}},
+			},
+			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+				Spans: []*trace.Span{{
+					TraceId: test.RandomBytes(16),
+					SpanId:  test.RandomBytes(8),
+					Name:    "test_span_a",
+				}},
+			}},
+		}},
+	}
+
+	bodyBytes, err := proto.Marshal(req)
+	assert.Nil(t, err)
+
+	buf := new(bytes.Buffer)
+	buf.Write(bodyBytes)
+
+	body := io.NopCloser(strings.NewReader(buf.String()))
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := TranslateTraceRequestFromReader(body, ri)
+	assert.Nil(t, result)
+	assert.Equal(t, ErrMissingServiceNameAttr, err)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #41 

## Short description of the changes

- Most SDKs will add a default service name if none are provided (`unknown_service:java`, etc). But in the (hopefully rare) scenario that a service name is missing or is an empty string, we should set the missing service name to `unknown_service`.
- this attempts to use `service.name` string value found in resource attributes. Service name will default to `unknown_service` if:
  - missing service name key or value in resource attributes
  - service name value is an empty string
  - service name value is not a string

Confirmed when sending empty service name string using otel-cli, no longer get "unable to resolve dataset error". Data is sent and new service name created `unknown_service`.