### PR TITLE
feat: truncate dataset name when service is unknown

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -87,7 +88,11 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 				if !ok || serviceName == "" {
 					dataset = defaultServiceName
 				} else {
-					dataset = serviceName
+					if strings.HasPrefix(serviceName, "unknown_service") {
+						dataset = defaultServiceName
+					} else {
+						dataset = serviceName
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- unknown service attribute can have unfriendly characters making it turn into a weird dataset once slugified
- updates #45 

## Short description of the changes

- if resource attribute starts with `unknown_service` --> truncate the dataset to just `unknown_service`
- event attribute is still the full resource attribute value

