### PR TITLE
feat: update metrics header validation

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -55,7 +55,7 @@ func (ri *RequestInfo) ValidateMetricsHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
-	if len(ri.Dataset) == 0 {
+	if isLegacy(ri.ApiKey) && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
 	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -153,29 +153,32 @@ func TestValidateTracesHeaders(t *testing.T) {
 
 func TestValidateMetricsHeaders(t *testing.T) {
 	testCases := []struct {
+		name        string
 		apikey      string
 		dataset     string
 		contentType string
 		err         error
 	}{
-		{apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
-		{apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
-		{apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
-		{apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
-		{apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/json", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
+		{name: "missing API key and missing dataset", apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
+		{name: "legacy API key and missing dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		{name: "new API key and missing dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
+		{name: "missing API key", apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
+		{name: "missing content-type", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
+		{name: "application/json content-type", apikey: "apikey", dataset: "dataset", contentType: "application/json", err: ErrInvalidContentType},
+		{name: "application/javascript content-type", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
+		{name: "application/xml content-type", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
+		{name: "application/octet-stream content-type", apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
+		{name: "text-plain content type", apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
+		{name: "application/protobuf content-type", apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "application/x-protobuf content-type", apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
 	}
 
 	for _, tc := range testCases {
-		ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
-		err := ri.ValidateMetricsHeaders()
-		assert.Equal(t, tc.err, err)
+		t.Run(tc.name, func(t *testing.T) {
+			ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
+			err := ri.ValidateMetricsHeaders()
+			assert.Equal(t, tc.err, err)
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- we want mis-configured metrics to end up in an `unknown_metrics` dataset (when using a non-legacy API key)
- updates https://github.com/honeycombio/telemetry-team/issues/188

## Short description of the changes

- validate metrics header is now (again) the same as validate traces headers, but I don't want to break the API (again) by consolidating the two functions into one. we can consolidate them in the future once the dust settles.
- add test granularity to make the results more readable

