### PR TITLE
Return sample rate of 1 if no sample rate key is found

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -20,7 +20,6 @@ import (
 const (
 	traceIDShortLength = 8
 	traceIDLongLength  = 16
-	zeroSampleRate     = int32(0)
 	defaultSampleRate  = int32(1)
 	defaultServiceName = "unknown_service"
 )
@@ -325,7 +324,7 @@ func parseOTLPBody(body io.ReadCloser, contentEncoding string) (request *collect
 func getSampleRate(attrs map[string]interface{}) int32 {
 	sampleRateKey := getSampleRateKey(attrs)
 	if sampleRateKey == "" {
-		return zeroSampleRate
+		return defaultSampleRate
 	}
 
 	sampleRate := defaultSampleRate

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -714,12 +714,12 @@ func TestInvalidBodyReturnsError(t *testing.T) {
 	assert.Equal(t, ErrFailedParseBody, err)
 }
 
-func TestNoSampleRateKeyReturnZero(t *testing.T) {
+func TestNoSampleRateKeyReturnOne(t *testing.T) {
 	attrs := map[string]interface{}{
 		"not_a_sample_rate": 10,
 	}
 	sampleRate := getSampleRate(attrs)
-	assert.Equal(t, int32(0), sampleRate)
+	assert.Equal(t, int32(1), sampleRate)
 }
 
 func TestCanDetectSampleRateCapitalizations(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
When a span does not contain a sample rate, we currently default to a sample rate of 0. Instead we should default to a sample rate of 1.

## Short description of the changes
- Return a default sample rate of 1 when if sample rate key is found
- Update tests

