### PR TITLE
feat: trim dataset when deriving from service.name

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -80,19 +80,13 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 		if isLegacy {
 			dataset = ri.Dataset
 		} else {
-			if resourceSpan.Resource == nil {
+			serviceName, ok := resourceAttrs["service.name"].(string)
+			if !ok ||
+				strings.TrimSpace(serviceName) == "" ||
+				strings.HasPrefix(serviceName, "unknown_service") {
 				dataset = defaultServiceName
 			} else {
-				serviceName, ok := resourceAttrs["service.name"].(string)
-				if !ok || serviceName == "" {
-					dataset = defaultServiceName
-				} else {
-					if strings.HasPrefix(serviceName, "unknown_service") {
-						dataset = defaultServiceName
-					} else {
-						dataset = serviceName
-					}
-				}
+				dataset = strings.TrimSpace(serviceName)
 			}
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- misconfigured service.name, such as ` ` or `\tmy-service\t`, when used as the dataset name, will result in weird behavior in the product (URL dataset will be a slug, hard to tell there's whitespace in the UI)
- updates https://github.com/honeycombio/telemetry-team/issues/196

## Short description of the changes

- trim service.name value prior to applying it as the dataset

