### PR TITLE
Update publish github filters in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,6 @@ workflows:
             - test
           filters:
             tags:
-              only: ^v[0-9]+\.[0-9]+\.[0-9]+(?:-.+)?$
+              only: /^v[0-9].*/
             branches:
               ignore: /.*/


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Fixes Circle CI publish_github job filters to run for tags. Job creates a draft github release.

- Closes #44 
- Closes #37 

## Short description of the changes
- Updates the _publish_github_ Circle CI job to apply valid filter

