### PR TITLE
default sample rate to 1 if omitted or if 0

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -347,6 +347,12 @@ func getSampleRate(attrs map[string]interface{}) int32 {
 			sampleRate = math.MaxInt32
 		}
 	}
+	// To make sampleRate consistent between Otel and Honeycomb, we coerce all 0 values to 1 here
+	// A value of 1 means the span was not sampled
+	// For full explanation, see https://app.asana.com/0/365940753298424/1201973146987622/f
+	if sampleRate == 0 {
+		sampleRate = 1
+	}
 	delete(attrs, sampleRateKey) // remove attr
 	return sampleRate
 }

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -351,7 +351,7 @@ func getSampleRate(attrs map[string]interface{}) int32 {
 	// A value of 1 means the span was not sampled
 	// For full explanation, see https://app.asana.com/0/365940753298424/1201973146987622/f
 	if sampleRate == 0 {
-		sampleRate = 1
+		sampleRate = defaultSampleRate
 	}
 	delete(attrs, sampleRateKey) // remove attr
 	return sampleRate

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -745,25 +745,25 @@ func TestGetSampleRateConversions(t *testing.T) {
 		expected   int32
 	}{
 		{sampleRate: nil, expected: 1},
-		{sampleRate: "0", expected: 0},
+		{sampleRate: "0", expected: 1},
 		{sampleRate: "1", expected: 1},
 		{sampleRate: "100", expected: 100},
 		{sampleRate: "invalid", expected: 1},
 		{sampleRate: strconv.Itoa(math.MaxInt32), expected: math.MaxInt32},
 		{sampleRate: strconv.Itoa(math.MaxInt64), expected: math.MaxInt32},
 
-		{sampleRate: 0, expected: 0},
+		{sampleRate: 0, expected: 1},
 		{sampleRate: 1, expected: 1},
 		{sampleRate: 100, expected: 100},
 		{sampleRate: math.MaxInt32, expected: math.MaxInt32},
 		{sampleRate: math.MaxInt64, expected: math.MaxInt32},
 
-		{sampleRate: int32(0), expected: 0},
+		{sampleRate: int32(0), expected: 1},
 		{sampleRate: int32(1), expected: 1},
 		{sampleRate: int32(100), expected: 100},
 		{sampleRate: int32(math.MaxInt32), expected: math.MaxInt32},
 
-		{sampleRate: int64(0), expected: 0},
+		{sampleRate: int64(0), expected: 1},
 		{sampleRate: int64(1), expected: 1},
 		{sampleRate: int64(100), expected: 100},
 		{sampleRate: int64(math.MaxInt32), expected: math.MaxInt32},


### PR DESCRIPTION
## Which problem is this PR solving?

Our documentation states that sample rate is optional and defaults to 1. 

Our code uses a go int value for sample rate, and believes that the default zero value and omitted sample rates are the same. 

Our instrumentation shows sample rate as either 0 or 1, confusing the people reading the instrumentation and making math on sample rates difficult. (AVG(app.sample_rate) is not accurate because of mixed 0s and 1s influencing the average but not changing the system's behavior.)

Otel documentation has a [different meaning for zero](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/tracestate-probability-sampling.md#adjusted-count), but that's not how our system works. That they're different leads to confusion.

## Short description of the changes

To clarify the current behavior for people reading code and looking at instrumentation, let's be explicit that both an omitted sample rate and sample rate explicitly set to zero are treated the same. Let's clarify by setting it to 1 in both cases. 

Co-authored-by: Michael Simo <michaelsimo@honeycomb.io>
