### PR TITLE
Fix library.version spillover between spans in a single batch

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -92,14 +92,6 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 
 		for _, librarySpan := range resourceSpan.InstrumentationLibrarySpans {
 			library := librarySpan.InstrumentationLibrary
-			if library != nil {
-				if len(library.Name) > 0 {
-					resourceAttrs["library.name"] = library.Name
-				}
-				if len(library.Version) > 0 {
-					resourceAttrs["library.version"] = library.Version
-				}
-			}
 
 			for _, span := range librarySpan.GetSpans() {
 				traceID := BytesToTraceID(span.TraceId)
@@ -126,6 +118,15 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 				if span.Status != nil && len(span.Status.Message) > 0 {
 					eventAttrs["status_message"] = span.Status.Message
 				}
+				if library != nil {
+					if len(library.Name) > 0 {
+						eventAttrs["library.name"] = library.Name
+					}
+					if len(library.Version) > 0 {
+						eventAttrs["library.version"] = library.Version
+					}
+				}
+
 				if span.Attributes != nil {
 					addAttributesToMap(eventAttrs, span.Attributes)
 				}

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -410,7 +410,7 @@ func TestTranslateGrpcTraceRequestFromMultipleLibraries(t *testing.T) {
 	third_event := events[2]
 	assert.Equal(t, "test_span_c", third_event.Attributes["name"])
 	assert.Equal(t, "No Version Library", third_event.Attributes["library.name"])
-	assert.Equal(t, "", third_event.Attributes["library.version"], "A library span with no library version shouldn't have a version.")
+	assert.Nil(t, third_event.Attributes["library.version"], "A library span with no library version shouldn't have a version.")
 }
 
 func TestTranslateLegacyHttpTraceRequest(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

- #68 

## Short description of the changes

- add a test for spans from multiple libraries in a single batch
- change from setting `library.(name|version)` via `resourceAttrs` to setting on each event