### PR TITLE
Copy span attrs after resource attrs

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -127,13 +127,14 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					}
 				}
 
-				if span.Attributes != nil {
-					addAttributesToMap(eventAttrs, span.Attributes)
-				}
-
 				// copy resource attributes to event attributes
 				for k, v := range resourceAttrs {
 					eventAttrs[k] = v
+				}
+
+				// copy span attribures after resource attributes so span attributes write last and are preserved
+				if span.Attributes != nil {
+					addAttributesToMap(eventAttrs, span.Attributes)
 				}
 
 				// Now we need to wrap the eventAttrs in an event so we can specify the timestamp


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Ensures span attributes are preserved in favour of resource attributes that has the samekey. The current behaviour has resource attrs preserved.

- Closes #73

## Short description of the changes
- Copy span attributes after resource attrs, they go into the same map so attrs with the same key are overwritten

