### PR TITLE
Convert OTLP span status.code type to integer earlier in the transform

### DIFF
--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -286,9 +286,7 @@ func evaluateSpanStatus(status *trace.Status) (int, bool) {
 		isError = true
 	case trace.Status_STATUS_CODE_UNSET:
 		//lint:ignore SA1019 keep DepCode until we move to proto v0.12.0+
-		if status.DeprecatedCode == trace.Status_DEPRECATED_STATUS_CODE_OK {
-			retStatusCode = int(trace.Status_STATUS_CODE_UNSET)
-		} else {
+		if status.DeprecatedCode != trace.Status_DEPRECATED_STATUS_CODE_OK {
 			retStatusCode = int(trace.Status_STATUS_CODE_ERROR)
 			isError = true
 		}

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -114,7 +114,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 				if span.ParentSpanId != nil {
 					eventAttrs["trace.parent_id"] = hex.EncodeToString(span.ParentSpanId)
 				}
-				if status_code == trace.Status_STATUS_CODE_ERROR {
+				if status_code == int(trace.Status_STATUS_CODE_ERROR) {
 					eventAttrs["error"] = true
 				}
 				if span.Status != nil && len(span.Status.Message) > 0 {
@@ -264,18 +264,18 @@ func shouldTrimTraceId(traceID []byte) bool {
 // notes in the protobuf definitions. See:
 //
 // https://github.com/open-telemetry/opentelemetry-proto/blob/59c488bfb8fb6d0458ad6425758b70259ff4a2bd/opentelemetry/proto/trace/v1/trace.proto#L230
-func evaluateSpanStatus(status *trace.Status) trace.Status_StatusCode {
+func evaluateSpanStatus(status *trace.Status) int {
 	if status == nil {
-		return trace.Status_STATUS_CODE_UNSET
+		return int(trace.Status_STATUS_CODE_UNSET)
 	}
 	if status.Code == trace.Status_STATUS_CODE_UNSET {
 		//lint:ignore SA1019 keep DepCode until we move to proto v0.12.0+
 		if status.DeprecatedCode == trace.Status_DEPRECATED_STATUS_CODE_OK {
-			return trace.Status_STATUS_CODE_UNSET
+			return int(trace.Status_STATUS_CODE_UNSET)
 		}
-		return trace.Status_STATUS_CODE_ERROR
+		return int(trace.Status_STATUS_CODE_ERROR)
 	}
-	return status.Code
+	return int(status.Code)
 }
 
 func parseOTLPBody(body io.ReadCloser, contentEncoding string) (request *collectorTrace.ExportTraceServiceRequest, err error) {

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -98,7 +98,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 				spanID := hex.EncodeToString(span.SpanId)
 
 				spanKind := getSpanKind(span.Kind)
-				status_code, isError := evaluateSpanStatus(span.Status)
+				statusCode, isError := evaluateSpanStatus(span.Status)
 
 				eventAttrs := map[string]interface{}{
 					"trace.trace_id":  traceID,
@@ -107,7 +107,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					"span.kind":       spanKind,
 					"name":            span.Name,
 					"duration_ms":     float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond),
-					"status_code":     status_code,
+					"status_code":     statusCode,
 					"span.num_links":  len(span.Links),
 					"span.num_events": len(span.Events),
 				}
@@ -277,7 +277,7 @@ func evaluateSpanStatus(status *trace.Status) (int, bool) {
 	}
 
 	isError := false
-	status_code := int(status.Code)
+	retStatusCode := int(status.Code)
 
 	switch status.Code {
 	case trace.Status_STATUS_CODE_OK:
@@ -287,14 +287,14 @@ func evaluateSpanStatus(status *trace.Status) (int, bool) {
 	case trace.Status_STATUS_CODE_UNSET:
 		//lint:ignore SA1019 keep DepCode until we move to proto v0.12.0+
 		if status.DeprecatedCode == trace.Status_DEPRECATED_STATUS_CODE_OK {
-			status_code = int(trace.Status_STATUS_CODE_UNSET)
+			retStatusCode = int(trace.Status_STATUS_CODE_UNSET)
 		} else {
-			status_code = int(trace.Status_STATUS_CODE_ERROR)
+			retStatusCode = int(trace.Status_STATUS_CODE_ERROR)
 			isError = true
 		}
 	}
 
-	return status_code, isError
+	return retStatusCode, isError
 }
 
 func parseOTLPBody(body io.ReadCloser, contentEncoding string) (request *collectorTrace.ExportTraceServiceRequest, err error) {

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -105,14 +105,14 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					"span.kind":       spanKind,
 					"name":            span.Name,
 					"duration_ms":     float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond),
-					"status_code":     getSpanStatusCode(span.Status),
+					"status_code":     evaluateSpanStatus(span.Status),
 					"span.num_links":  len(span.Links),
 					"span.num_events": len(span.Events),
 				}
 				if span.ParentSpanId != nil {
 					eventAttrs["trace.parent_id"] = hex.EncodeToString(span.ParentSpanId)
 				}
-				if getSpanStatusCode(span.Status) == trace.Status_STATUS_CODE_ERROR {
+				if evaluateSpanStatus(span.Status) == trace.Status_STATUS_CODE_ERROR {
 					eventAttrs["error"] = true
 				}
 				if span.Status != nil && len(span.Status.Message) > 0 {
@@ -257,12 +257,12 @@ func shouldTrimTraceId(traceID []byte) bool {
 	return true
 }
 
-// getSpanStatusCode checks the value of both the deprecated code and code fields
+// evaluateSpanStatus checks the value of both the deprecated code and code fields
 // on the span status and using the rules specified in the backward compatibility
 // notes in the protobuf definitions. See:
 //
 // https://github.com/open-telemetry/opentelemetry-proto/blob/59c488bfb8fb6d0458ad6425758b70259ff4a2bd/opentelemetry/proto/trace/v1/trace.proto#L230
-func getSpanStatusCode(status *trace.Status) trace.Status_StatusCode {
+func evaluateSpanStatus(status *trace.Status) trace.Status_StatusCode {
 	if status == nil {
 		return trace.Status_STATUS_CODE_UNSET
 	}

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -98,6 +98,8 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 				spanID := hex.EncodeToString(span.SpanId)
 
 				spanKind := getSpanKind(span.Kind)
+				status_code := evaluateSpanStatus(span.Status)
+
 				eventAttrs := map[string]interface{}{
 					"trace.trace_id":  traceID,
 					"trace.span_id":   spanID,
@@ -105,14 +107,14 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					"span.kind":       spanKind,
 					"name":            span.Name,
 					"duration_ms":     float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond),
-					"status_code":     evaluateSpanStatus(span.Status),
+					"status_code":     status_code,
 					"span.num_links":  len(span.Links),
 					"span.num_events": len(span.Events),
 				}
 				if span.ParentSpanId != nil {
 					eventAttrs["trace.parent_id"] = hex.EncodeToString(span.ParentSpanId)
 				}
-				if evaluateSpanStatus(span.Status) == trace.Status_STATUS_CODE_ERROR {
+				if status_code == trace.Status_STATUS_CODE_ERROR {
 					eventAttrs["error"] = true
 				}
 				if span.Status != nil && len(span.Status.Message) > 0 {

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -267,6 +267,7 @@ func getSpanStatusCode(status *trace.Status) trace.Status_StatusCode {
 		return trace.Status_STATUS_CODE_UNSET
 	}
 	if status.Code == trace.Status_STATUS_CODE_UNSET {
+		//lint:ignore SA1019 keep DepCode until we move to proto v0.12.0+
 		if status.DeprecatedCode == trace.Status_DEPRECATED_STATUS_CODE_OK {
 			return trace.Status_STATUS_CODE_UNSET
 		}

--- a/otlp/trace.go
+++ b/otlp/trace.go
@@ -272,8 +272,11 @@ func shouldTrimTraceId(traceID []byte) bool {
 //
 // See: https://github.com/open-telemetry/opentelemetry-proto/blob/59c488bfb8fb6d0458ad6425758b70259ff4a2bd/opentelemetry/proto/trace/v1/trace.proto#L230
 func evaluateSpanStatus(status *trace.Status) (int, bool) {
+	const unsetStatus = int(trace.Status_STATUS_CODE_UNSET)
+	const errorStatus = int(trace.Status_STATUS_CODE_ERROR)
+
 	if status == nil {
-		return int(trace.Status_STATUS_CODE_UNSET), false
+		return unsetStatus, false
 	}
 
 	isError := false
@@ -287,7 +290,7 @@ func evaluateSpanStatus(status *trace.Status) (int, bool) {
 	case trace.Status_STATUS_CODE_UNSET:
 		//lint:ignore SA1019 keep DepCode until we move to proto v0.12.0+
 		if status.DeprecatedCode != trace.Status_DEPRECATED_STATUS_CODE_OK {
-			retStatusCode = int(trace.Status_STATUS_CODE_ERROR)
+			retStatusCode = errorStatus
 			isError = true
 		}
 	}

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -1168,7 +1168,7 @@ func TestServiceNameIsTrimmedForDataset(t *testing.T) {
 	}
 }
 
-func TestGetSpanStatusCode(t *testing.T) {
+func TestEvaluateSpanStatus(t *testing.T) {
 	testCases := []struct {
 		desc               string
 		status             *trace.Status
@@ -1218,7 +1218,7 @@ func TestGetSpanStatusCode(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			status_code := getSpanStatusCode(tC.status)
+			status_code := evaluateSpanStatus(tC.status)
 			assert.Equal(t, tC.expectedStatusCode, status_code)
 		})
 	}

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -119,7 +119,7 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "test_span", ev.Attributes["name"])
 	assert.Equal(t, "my-service", ev.Attributes["service.name"])
 	assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
-	assert.Equal(t, trace.Status_STATUS_CODE_OK, ev.Attributes["status_code"])
+	assert.Equal(t, int(trace.Status_STATUS_CODE_OK), ev.Attributes["status_code"])
 	assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 	assert.Equal(t, 1, ev.Attributes["span.num_links"])
@@ -247,7 +247,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "client", ev.Attributes["span.kind"])
 	assert.Equal(t, "test_span", ev.Attributes["name"])
 	assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
-	assert.Equal(t, trace.Status_STATUS_CODE_OK, ev.Attributes["status_code"])
+	assert.Equal(t, int(trace.Status_STATUS_CODE_OK), ev.Attributes["status_code"])
 	assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 	assert.Equal(t, 1, ev.Attributes["span.num_links"])
@@ -523,7 +523,7 @@ func TestTranslateLegacyHttpTraceRequest(t *testing.T) {
 			assert.Equal(t, "test_span", ev.Attributes["name"])
 			assert.Equal(t, "my-service", ev.Attributes["service.name"])
 			assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
-			assert.Equal(t, trace.Status_STATUS_CODE_OK, ev.Attributes["status_code"])
+			assert.Equal(t, int(trace.Status_STATUS_CODE_OK), ev.Attributes["status_code"])
 			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 
@@ -661,7 +661,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 			assert.Equal(t, "test_span", ev.Attributes["name"])
 			assert.Equal(t, "my-service", ev.Attributes["service.name"])
 			assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
-			assert.Equal(t, trace.Status_STATUS_CODE_OK, ev.Attributes["status_code"])
+			assert.Equal(t, int(trace.Status_STATUS_CODE_OK), ev.Attributes["status_code"])
 			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 
@@ -1172,12 +1172,12 @@ func TestEvaluateSpanStatus(t *testing.T) {
 	testCases := []struct {
 		desc               string
 		status             *trace.Status
-		expectedStatusCode trace.Status_StatusCode
+		expectedStatusCode int
 	}{
 		{
 			desc:               "returns unset when status is nil",
 			status:             nil,
-			expectedStatusCode: trace.Status_STATUS_CODE_UNSET,
+			expectedStatusCode: int(trace.Status_STATUS_CODE_UNSET),
 		},
 		// Cases for the rules for old receivers at:
 		// https://github.com/open-telemetry/opentelemetry-proto/blob/59c488bfb8fb6d0458ad6425758b70259ff4a2bd/opentelemetry/proto/trace/v1/trace.proto#L251-L266
@@ -1191,7 +1191,7 @@ func TestEvaluateSpanStatus(t *testing.T) {
 				DeprecatedCode: trace.Status_DEPRECATED_STATUS_CODE_OK,
 				Message:        "Old OK!",
 			},
-			expectedStatusCode: trace.Status_STATUS_CODE_UNSET,
+			expectedStatusCode: int(trace.Status_STATUS_CODE_UNSET),
 		},
 		//   If code==STATUS_CODE_UNSET [and] deprecated_code!=DEPRECATED_STATUS_CODE_OK
 		//   then the receiver MUST interpret the overall status to be STATUS_CODE_ERROR.
@@ -1202,7 +1202,7 @@ func TestEvaluateSpanStatus(t *testing.T) {
 				DeprecatedCode: trace.Status_DEPRECATED_STATUS_CODE_ABORTED,
 				Message:        "Old not OK!",
 			},
-			expectedStatusCode: trace.Status_STATUS_CODE_ERROR,
+			expectedStatusCode: int(trace.Status_STATUS_CODE_ERROR),
 		},
 		//   If code!=STATUS_CODE_UNSET then the value of `deprecated_code` MUST be
 		//   ignored, the `code` field is the sole carrier of the status.
@@ -1213,7 +1213,7 @@ func TestEvaluateSpanStatus(t *testing.T) {
 				DeprecatedCode: trace.Status_DEPRECATED_STATUS_CODE_OK,
 				Message:        "Old OK!",
 			},
-			expectedStatusCode: trace.Status_STATUS_CODE_ERROR,
+			expectedStatusCode: int(trace.Status_STATUS_CODE_ERROR),
 		},
 	}
 	for _, tC := range testCases {

--- a/otlp/trace_test.go
+++ b/otlp/trace_test.go
@@ -1223,8 +1223,8 @@ func TestEvaluateSpanStatus(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			status_code, isError := evaluateSpanStatus(tC.status)
-			assert.Equal(t, tC.expectedStatusCode, status_code)
+			statusCode, isError := evaluateSpanStatus(tC.status)
+			assert.Equal(t, tC.expectedStatusCode, statusCode)
 			assert.Equal(t, tC.expectedIsError, isError)
 		})
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

**Sign/Symptom:** 

A customer reported that `status_code` values had stopped appearing abruptly in one of their datasets. They had changed the type of the `status_code` column in the dataset schema from string to integer. _This is a totally reasonable thing to do because an OpenTelemetry span status code is an integer._

**Origin:**

Prior to this change, Husky sets `status_code` to a `trace.Status_StatusCode` type from the trace.pb.go generated from OTLP proto definitions. For Reasons™, that type _would_ convert to a string during our data ingest, but would _not_ convert to an integer (despite the type's association with actual `int32` constants).

## Short description of the changes

We'll now do the type conversion from OTLP proto enum shenanigans to an `int` here in husky's transform of an OTLP span into an event. The events we produce from OTLP spans have no knowledge of or interest in the OTLP types generated from enums in the proto definitions.

