### PR TITLE
Rename translate OTLP request structs to be generic

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -95,6 +95,7 @@ func (ri *RequestInfo) ValidateMetricsHeaders() error {
 	return nil
 }
 
+// ValidateLogsHeaders validates required headers/metadata for a logs OTLP request
 func (ri *RequestInfo) ValidateLogsHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -31,10 +31,10 @@ const (
 
 var legacyApiKeyPattern = regexp.MustCompile("^[0-9a-f]{32}$")
 
-// TranslateTraceRequestResult represents an OTLP trace request translated into Honeycomb-friendly structure
+// TranslateOTLPRequestResult represents an OTLP request translated into Honeycomb-friendly structure
 // RequestSize is total byte size of the entire OTLP request
 // Batches represent events grouped by their target dataset
-type TranslateTraceRequestResult struct {
+type TranslateOTLPRequestResult struct {
 	RequestSize int
 	Batches     []Batch
 }

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -13,7 +13,7 @@ import (
 
 // TranslateLogsRequestFromReader translates an OTLP log request into Honeycomb-friendly structure from a reader (eg HTTP body)
 // RequestInfo is the parsed information from the gRPC metadata
-func TranslateLogsRequestFromReader(body io.ReadCloser, ri RequestInfo) (*TranslateTraceRequestResult, error) {
+func TranslateLogsRequestFromReader(body io.ReadCloser, ri RequestInfo) (*TranslateOTLPRequestResult, error) {
 	if err := ri.ValidateLogsHeaders(); err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func TranslateLogsRequestFromReader(body io.ReadCloser, ri RequestInfo) (*Transl
 
 // TranslateLogsRequest translates an OTLP proto log request into Honeycomb-friendly structure
 // RequestInfo is the parsed information from the gRPC metadata
-func TranslateLogsRequest(request *collectorLogs.ExportLogsServiceRequest, ri RequestInfo) (*TranslateTraceRequestResult, error) {
+func TranslateLogsRequest(request *collectorLogs.ExportLogsServiceRequest, ri RequestInfo) (*TranslateOTLPRequestResult, error) {
 	if err := ri.ValidateLogsHeaders(); err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func TranslateLogsRequest(request *collectorLogs.ExportLogsServiceRequest, ri Re
 			Events:    events,
 		})
 	}
-	return &TranslateTraceRequestResult{
+	return &TranslateOTLPRequestResult{
 		RequestSize: proto.Size(request),
 		Batches:     batches,
 	}, nil

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -22,7 +22,7 @@ const (
 
 // TranslateTraceRequestFromReader translates an OTLP/HTTP request into Honeycomb-friendly structure
 // RequestInfo is the parsed information from the HTTP headers
-func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) (*TranslateTraceRequestResult, error) {
+func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) (*TranslateOTLPRequestResult, error) {
 	if err := ri.ValidateTracesHeaders(); err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) (*Trans
 
 // TranslateTraceRequest translates an OTLP/gRPC request into Honeycomb-friendly structure
 // RequestInfo is the parsed information from the gRPC metadata
-func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri RequestInfo) (*TranslateTraceRequestResult, error) {
+func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri RequestInfo) (*TranslateOTLPRequestResult, error) {
 	if err := ri.ValidateTracesHeaders(); err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 			Events:    events,
 		})
 	}
-	return &TranslateTraceRequestResult{
+	return &TranslateOTLPRequestResult{
 		RequestSize: proto.Size(request),
 		Batches:     batches,
 	}, nil


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Renames the TranslateTraceRequestResult struct to be generic.

- Closes #89

## Short description of the changes
- Rename TranslateTraceRequestResult to TranslateOTLPRequestResult
- Add missing description to ValidateLogsHeaders func

