### PR TITLE
Only set meta.annotation_type field when log is part of trace

### DIFF
--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -59,14 +59,15 @@ func TranslateLogsRequest(request *collectorLogs.ExportLogsServiceRequest, ri Re
 
 			for _, log := range librarySpan.GetLogs() {
 				eventAttrs := map[string]interface{}{
-					"severity":             getLogSeverity(log.SeverityNumber),
-					"severity_code":        int(log.SeverityNumber),
-					"meta.signal_type":     "log",
-					"meta.annotation_type": "span_event",
-					"flags":                log.Flags,
+					"severity":         getLogSeverity(log.SeverityNumber),
+					"severity_code":    int(log.SeverityNumber),
+					"meta.signal_type": "log",
+					"flags":            log.Flags,
 				}
 				if len(log.TraceId) > 0 {
 					eventAttrs["trace.trace_id"] = BytesToTraceID(log.TraceId)
+					// only add meta.annotation_type if the log is associated to a trace
+					eventAttrs["meta.annotation_type"] = "span_event"
 				}
 				if len(log.SpanId) > 0 {
 					eventAttrs["trace.parent_id"] = hex.EncodeToString(log.SpanId)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
It's important that meta.annotation_type is only set when a log is part of a trace, otherwise data can look strange in datasets that only contain logs.

## Short description of the changes
- Only set the meta.annotation_type field when the log has a trace ID associated to it
- Add unit test to verify annotation_type is set correctly

