### PR TITLE
Fix flaky invalid OTLP request body test

### DIFF
--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -777,7 +777,7 @@ func TestInvalidContentTypeReturnsError(t *testing.T) {
 }
 
 func TestInvalidBodyReturnsError(t *testing.T) {
-	bodyBytes := test.RandomBytes(10)
+	bodyBytes := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
 	body := io.NopCloser(bytes.NewReader(bodyBytes))
 	ri := RequestInfo{
 		ApiKey:      "apikey",


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The test `TestInvalidBodyReturnsError` was flaky because it randomly generates 10 bytes which will normally generate an invalid OTLP request. However, it could occationally generate a valid OTLP request with no records which makes the test fail as it expects an error to be returned.

This change updates the test to use a consistent set of bytes that we know to create an invalid request.

## Short description of the changes
- Update `TestInvalidBodyReturnsError` to use consistent bytes

