### PR TITLE
Add go.work to help manage multiple modules

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.18
+
+use (
+	./
+	./otlp-proto
+)

--- a/go.work
+++ b/go.work
@@ -2,5 +2,5 @@ go 1.18
 
 use (
 	./
-	./otlp-proto
+	./internal/go.opentelemetry.io/proto/otlp
 )


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The go.work file helps indicate a repo contains multiple pacakges. This PR adds one to separate the main package (husky) and the OTLP proto fork (otlp-proto)

## Short description of the changes
- Adds go.work to help manage multiple pacakges

