### PR TITLE
Add support for scope attributes when translating traces & metrics requests

### DIFF
--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -56,6 +56,9 @@ func TranslateLogsRequest(request *collectorLogs.ExportLogsServiceRequest, ri Re
 
 		for _, scopeLog := range resourceLog.ScopeLogs {
 			scope := scopeLog.Scope
+			if scope != nil {
+				addAttributesToMap(resourceAttrs, scope.Attributes)
+			}
 
 			for _, log := range scopeLog.GetLogRecords() {
 				eventAttrs := map[string]interface{}{

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -42,6 +42,18 @@ func TestTranslateLogsRequest(t *testing.T) {
 				}},
 			},
 			ScopeLogs: []*logs.ScopeLogs{{
+				Scope: &common.InstrumentationScope{
+					Name:    "scope-name",
+					Version: "scope-version",
+					Attributes: []*common.KeyValue{
+						{
+							Key: "scope_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
+							},
+						},
+					},
+				},
 				LogRecords: []*logs.LogRecord{{
 					TraceId:        traceID,
 					SpanId:         spanID,
@@ -83,6 +95,7 @@ func TestTranslateLogsRequest(t *testing.T) {
 	assert.Equal(t, "my-service", ev.Attributes["service.name"])
 	assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+	assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 }
 
 func TestTranslateClassicLogsRequest(t *testing.T) {

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -65,6 +65,9 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 
 		for _, scopeSpan := range resourceSpan.ScopeSpans {
 			scope := scopeSpan.Scope
+			if scope != nil {
+				addAttributesToMap(resourceAttrs, scope.Attributes)
+			}
 
 			for _, span := range scopeSpan.GetSpans() {
 				traceID := BytesToTraceID(span.TraceId)

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -52,6 +52,18 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 				}},
 			},
 			ScopeSpans: []*trace.ScopeSpans{{
+				Scope: &common.InstrumentationScope{
+					Name:    "scope-name",
+					Version: "scope-version",
+					Attributes: []*common.KeyValue{
+						{
+							Key: "scope_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
+							},
+						},
+					},
+				},
 				Spans: []*trace.Span{{
 					TraceId:           traceID,
 					SpanId:            spanID,
@@ -125,6 +137,7 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 	assert.Equal(t, 1, ev.Attributes["span.num_links"])
 	assert.Equal(t, 1, ev.Attributes["span.num_events"])
+	assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 
 	// event
 	ev = events[1]
@@ -137,6 +150,7 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
 	assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+	assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 
 	// link
 	ev = events[2]
@@ -151,6 +165,7 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
 	assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+	assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 }
 
 func TestTranslateGrpcTraceRequest(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds support for recording scope level attributes when translating OTLP traces and metrics requests.

- Closes https://github.com/honeycombio/telemetry-team/issues/322
- Unblocks #108 

## Short description of the changes
- Adds scope attributes to the resource attributes list when translating trace and metrics requests
- Add unit tests to verify the attributes are being recorded correctly.