### PR TITLE
Add support for translating otlp/json trace and log requests

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -106,10 +106,12 @@ func (ri *RequestInfo) ValidateLogsHeaders() error {
 	if isLegacy(ri.ApiKey) && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
-	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
+	switch ri.ContentType {
+	case "application/protobuf", "application/x-protobuf", "application/json":
+		return nil
+	default:
 		return ErrInvalidContentType
 	}
-	return nil
 }
 
 // GetRequestInfoFromGrpcMetadata parses relevant gRPC metadata from an incoming request context

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -252,7 +252,7 @@ func parseOtlpRequestBody(body io.ReadCloser, contentType string, contentEncodin
 	}
 
 	switch contentType {
-	case "application/protobuf":
+	case "application/protobuf", "application/x-protobuf":
 		err = proto.Unmarshal(bytes, request)
 	case "application/json":
 		err = protojson.Unmarshal(bytes, request)

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -251,10 +251,13 @@ func parseOtlpRequestBody(body io.ReadCloser, contentType string, contentEncodin
 		return err
 	}
 
-	if contentType == "application/json" {
-		err = protojson.Unmarshal(bytes, request)
-	} else {
+	switch contentType {
+	case "application/protobuf":
 		err = proto.Unmarshal(bytes, request)
+	case "application/json":
+		err = protojson.Unmarshal(bytes, request)
+	default:
+		return ErrInvalidContentType
 	}
 	if err != nil {
 		return err

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -135,13 +135,13 @@ func TestValidateTracesHeaders(t *testing.T) {
 		{apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
 		{apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
 		{apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/json", err: ErrInvalidContentType},
 		{apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
 		{apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
 		{apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
 		{apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
 		{apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
 		{apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
+		{apikey: "apikey", dataset: "dataset", contentType: "application/json", err: nil},
 	}
 
 	for _, tc := range testCases {

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -18,7 +18,7 @@ func TranslateLogsRequestFromReader(body io.ReadCloser, ri RequestInfo) (*Transl
 		return nil, err
 	}
 	request := &collectorLogs.ExportLogsServiceRequest{}
-	if err := parseOtlpRequestBody(body, ri.ContentEncoding, request); err != nil {
+	if err := parseOtlpRequestBody(body, ri.ContentType, ri.ContentEncoding, request); err != nil {
 		return nil, ErrFailedParseBody
 	}
 	return TranslateLogsRequest(request, ri)

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -280,8 +280,8 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 			assert.Equal(t, "my-service", ev.Attributes["service.name"])
 			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-			assert.Equal(t, "instr_scope_name", ev.Attributes["instrumentation_scope.name"])
-			assert.Equal(t, "instr_scope_version", ev.Attributes["instrumentation_scope.version"])
+			assert.Equal(t, "instr_scope_name", ev.Attributes["library.name"])
+			assert.Equal(t, "instr_scope_version", ev.Attributes["library.version"])
 			assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 		}
 	}

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -521,7 +521,7 @@ func TestLogsRequestWithInvalidContentTypeReturnsError(t *testing.T) {
 	req := &collectorlogs.ExportLogsServiceRequest{}
 	ri := RequestInfo{
 		ApiKey:      "apikey",
-		ContentType: "application/json",
+		ContentType: "application/binary",
 	}
 
 	result, err := TranslateLogsRequest(req, ri)

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -27,7 +27,7 @@ func TranslateTraceRequestFromReader(body io.ReadCloser, ri RequestInfo) (*Trans
 		return nil, err
 	}
 	request := &collectorTrace.ExportTraceServiceRequest{}
-	if err := parseOtlpRequestBody(body, ri.ContentEncoding, request); err != nil {
+	if err := parseOtlpRequestBody(body, ri.ContentType, ri.ContentEncoding, request); err != nil {
 		return nil, ErrFailedParseBody
 	}
 	return TranslateTraceRequest(request, ri)

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -790,7 +790,7 @@ func TestInvalidContentTypeReturnsError(t *testing.T) {
 	ri := RequestInfo{
 		ApiKey:      "apikey",
 		Dataset:     "dataset",
-		ContentType: "application/json",
+		ContentType: "application/binary",
 	}
 
 	result, err := TranslateTraceRequestFromReader(body, ri)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
This PR adds support for translating OTLP/JSON trace and log requests. This is achieve by checking the contentType header and using `protojson.Unmarshal` to decode the request into a protobuf message.

## Short description of the changes
- Update trace and log header validation to allow application/json
- Use content type header to switch between protobuf and json unmarshal when decoding HTTP body
- Extend trace tests to test both protobuf and json requests can be decoded with different encodings 
- Add log tests to verify log requests can be decided with different encoding