### PR TITLE
Don't duplicate scope attributes between scopes

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -9,9 +9,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	common "github.com/honeycombio/husky/proto/otlp/common/v1"
+	resource "github.com/honeycombio/husky/proto/otlp/resource/v1"
 	"github.com/klauspost/compress/zstd"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
@@ -27,6 +29,7 @@ const (
 	contentTypeHeader        = "content-type"
 	contentEncodingHeader    = "content-encoding"
 	gRPCAcceptEncodingHeader = "grpc-accept-encoding"
+	defaultServiceName       = "unknown_service"
 )
 
 var legacyApiKeyPattern = regexp.MustCompile("^[0-9a-f]{32}$")
@@ -67,12 +70,16 @@ type RequestInfo struct {
 	GRPCAcceptEncoding string
 }
 
+func (ri RequestInfo) hasLegacyKey() bool {
+	return legacyApiKeyPattern.MatchString(ri.ApiKey)
+}
+
 // ValidateTracesHeaders validates required headers/metadata for a trace OTLP request
 func (ri *RequestInfo) ValidateTracesHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
-	if isLegacy(ri.ApiKey) && len(ri.Dataset) == 0 {
+	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
 	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
@@ -86,7 +93,7 @@ func (ri *RequestInfo) ValidateMetricsHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
-	if isLegacy(ri.ApiKey) && len(ri.Dataset) == 0 {
+	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
 	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
@@ -100,7 +107,7 @@ func (ri *RequestInfo) ValidateLogsHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
-	if isLegacy(ri.ApiKey) && len(ri.Dataset) == 0 {
+	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
 	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
@@ -159,18 +166,43 @@ func addAttributesToMap(attrs map[string]interface{}, attributes []*common.KeyVa
 	}
 }
 
-func addScopeToMap(attrs map[string]interface{}, scope *common.InstrumentationScope) {
+func getResourceAttributes(resource *resource.Resource) map[string]interface{} {
+	attrs := map[string]interface{}{}
+	if resource != nil {
+		addAttributesToMap(attrs, resource.Attributes)
+	}
+	return attrs
+}
+
+func getScopeAttributes(scope *common.InstrumentationScope) map[string]interface{} {
+	attrs := map[string]interface{}{}
 	if scope != nil {
 		if scope.Name != "" {
-			attrs["instrumentation_scope.name"] = scope.Name
+			attrs["library.name"] = scope.Name
 		}
 		if scope.Version != "" {
-			attrs["instrumentation_scope.version"] = scope.Version
+			attrs["library.version"] = scope.Version
 		}
-		if scope.Attributes != nil {
-			addAttributesToMap(attrs, scope.Attributes)
+		addAttributesToMap(attrs, scope.Attributes)
+	}
+	return attrs
+}
+
+func getDataset(ri RequestInfo, attrs map[string]interface{}) string {
+	var dataset string
+	if ri.hasLegacyKey() {
+		dataset = ri.Dataset
+	} else {
+		serviceName, ok := attrs["service.name"].(string)
+		if !ok ||
+			strings.TrimSpace(serviceName) == "" ||
+			strings.HasPrefix(serviceName, "unknown_service") {
+			dataset = defaultServiceName
+		} else {
+			dataset = strings.TrimSpace(serviceName)
 		}
 	}
+	return dataset
 }
 
 func getValue(value *common.AnyValue) interface{} {
@@ -207,10 +239,6 @@ func getValue(value *common.AnyValue) interface{} {
 		}
 	}
 	return nil
-}
-
-func isLegacy(apiKey string) bool {
-	return legacyApiKeyPattern.MatchString(apiKey)
 }
 
 func parseOtlpRequestBody(body io.ReadCloser, contentEncoding string, request protoreflect.ProtoMessage) error {

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -43,8 +43,8 @@ func TestTranslateLogsRequest(t *testing.T) {
 			},
 			ScopeLogs: []*logs.ScopeLogs{{
 				Scope: &common.InstrumentationScope{
-					Name:    "instr_scope_name",
-					Version: "instr_scope_version",
+					Name:    "library-name",
+					Version: "library-version",
 					Attributes: []*common.KeyValue{
 						{
 							Key: "scope_attr",
@@ -95,8 +95,8 @@ func TestTranslateLogsRequest(t *testing.T) {
 	assert.Equal(t, "my-service", ev.Attributes["service.name"])
 	assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-	assert.Equal(t, "instr_scope_name", ev.Attributes["instrumentation_scope.name"])
-	assert.Equal(t, "instr_scope_version", ev.Attributes["instrumentation_scope.version"])
+	assert.Equal(t, "library-name", ev.Attributes["library.name"])
+	assert.Equal(t, "library-version", ev.Attributes["library.version"])
 	assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 }
 

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -53,8 +53,8 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 			},
 			ScopeSpans: []*trace.ScopeSpans{{
 				Scope: &common.InstrumentationScope{
-					Name:    "instr_scope_name",
-					Version: "instr_scope_version",
+					Name:    "library-name",
+					Version: "library-version",
 					Attributes: []*common.KeyValue{
 						{
 							Key: "scope_attr",
@@ -137,8 +137,8 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 	assert.Equal(t, 1, ev.Attributes["span.num_links"])
 	assert.Equal(t, 1, ev.Attributes["span.num_events"])
-	assert.Equal(t, "instr_scope_name", ev.Attributes["instrumentation_scope.name"])
-	assert.Equal(t, "instr_scope_version", ev.Attributes["instrumentation_scope.version"])
+	assert.Equal(t, "library-name", ev.Attributes["library.name"])
+	assert.Equal(t, "library-version", ev.Attributes["library.version"])
 	assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 
 	// event
@@ -152,8 +152,8 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
 	assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-	assert.Equal(t, "instr_scope_name", ev.Attributes["instrumentation_scope.name"])
-	assert.Equal(t, "instr_scope_version", ev.Attributes["instrumentation_scope.version"])
+	assert.Equal(t, "library-name", ev.Attributes["library.name"])
+	assert.Equal(t, "library-version", ev.Attributes["library.version"])
 	assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 
 	// link
@@ -169,8 +169,8 @@ func TestTranslateLegacyGrpcTraceRequest(t *testing.T) {
 	assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
 	assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
 	assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-	assert.Equal(t, "instr_scope_name", ev.Attributes["instrumentation_scope.name"])
-	assert.Equal(t, "instr_scope_version", ev.Attributes["instrumentation_scope.version"])
+	assert.Equal(t, "library-name", ev.Attributes["library.name"])
+	assert.Equal(t, "library-version", ev.Attributes["library.version"])
 	assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Scope attributes were being carried over between scope entries which can lead to incorrect attributes being added to events. This change introduced a new utility func that extracts resource attributes and scope attributes and returns a new map[string]interface{} which is run per

## Short description of the changes
- add getDataset to remove duplicate code
- move defaultService const to common
- make IsLegacy func a RequestInfo member
- add getResourceAttributes and getScopeAttributes utility funcs
- make sure we always apply attributes in order - resource ->  scope -> span/log