### PR TITLE
[feat] allow OTLP/http-json for metrics

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -105,22 +105,35 @@ func (ri RequestInfo) hasLegacyKey() bool {
 	return legacyApiKeyPattern.MatchString(ri.ApiKey)
 }
 
-// ValidateTracesHeaders validates required headers/metadata for a trace OTLP request
+// ValidateTracesHeaders checks for required headers/metadata for all OTLP requests
+// and specific to Traces.
 func (ri *RequestInfo) ValidateTracesHeaders() error {
-	if len(ri.ApiKey) == 0 {
-		return ErrMissingAPIKeyHeader
-	}
-	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
-		return ErrMissingDatasetHeader
-	}
-	if !IsContentTypeSupported(ri.ContentType) {
-		return ErrInvalidContentType
-	}
-	return nil // no error, headers passed all the validations
+	// validations specific to traces
+	// - none for now
+	// validations common for all OTLP requests
+	return validateHeaders(ri)
 }
 
-// ValidateMetricsHeaders validates required headers/metadata for a metric OTLP request
+// ValidateMetricsHeaders checks for required headers/metadata for all OTLP requests
+// and specific to Metrics.
 func (ri *RequestInfo) ValidateMetricsHeaders() error {
+	// validations specific to metrics
+	// - none for now
+	// validations common for all OTLP requests
+	return validateHeaders(ri)
+}
+
+// ValidateLogsHeaders checks for required headers/metadata for all OTLP requests
+// and specific to Logs.
+func (ri *RequestInfo) ValidateLogsHeaders() error {
+	// validations specific to logs
+	// - none for now
+	// validations common for all OTLP requests
+	return validateHeaders(ri)
+}
+
+// Header validation that is common across OTLP signal requests.
+func validateHeaders(ri *RequestInfo) error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
@@ -131,20 +144,6 @@ func (ri *RequestInfo) ValidateMetricsHeaders() error {
 		return ErrInvalidContentType
 	}
 	return nil // no error, headers passed all the validations
-}
-
-// ValidateLogsHeaders validates required headers/metadata for a logs OTLP request
-func (ri *RequestInfo) ValidateLogsHeaders() error {
-	if len(ri.ApiKey) == 0 {
-		return ErrMissingAPIKeyHeader
-	}
-	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
-		return ErrMissingDatasetHeader
-	}
-	if !IsContentTypeSupported(ri.ContentType) {
-		return ErrInvalidContentType
-	}
-	return nil
 }
 
 // GetRequestInfoFromGrpcMetadata parses relevant gRPC metadata from an incoming request context

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -41,6 +41,8 @@ var (
 		"application/x-protobuf",
 		"application/json",
 	}
+	// Incoming Content-Encodings we support. "" included as a stand in for "not given, assume uncompressed"
+	supportedContentEncodings = []string{"", "gzip", "zstd"}
 )
 
 // List of HTTP Content Types supported for OTLP ingest.
@@ -56,6 +58,11 @@ func IsContentTypeSupported(contentType string) bool {
 		}
 	}
 	return false
+}
+
+// List of HTTP Content Encodings supported for OTLP ingest.
+func GetSupportedContentEncodings() []string {
+	return supportedContentEncodings
 }
 
 // TranslateOTLPRequestResult represents an OTLP request translated into Honeycomb-friendly structure

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -41,25 +41,16 @@ var (
 		"application/x-protobuf",
 		"application/json",
 	}
-	// A map populated by init() from supportedContentTypes for quick checking that a type is supported.
-	//
-	// Ex:
-	//     if checkSupportedContentType[request.contentType] {
-	//        // we support this type, proceed
-	//     } else {
-	//        // unsupported media type, probably return an error
-	//     }
-	//
-	// Ex:
-	//     switch
-	checkSupportedContentType map[string]bool
 )
 
-func init() {
-	checkSupportedContentType = make(map[string]bool)
-	for _, contentType := range supportedContentTypes {
-		checkSupportedContentType[contentType] = true
+// Check whether we support a given HTTP Content Type for OTLP.
+func IsContentTypeSupported(contentType string) bool {
+	for _, supportedType := range supportedContentTypes {
+		if contentType == supportedType {
+			return true
+		}
 	}
+	return false
 }
 
 // TranslateOTLPRequestResult represents an OTLP request translated into Honeycomb-friendly structure
@@ -110,7 +101,7 @@ func (ri *RequestInfo) ValidateTracesHeaders() error {
 	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
-	if checkSupportedContentType[ri.ContentType] {
+	if IsContentTypeSupported(ri.ContentType) {
 		return nil
 	} else {
 		return ErrInvalidContentType
@@ -125,7 +116,7 @@ func (ri *RequestInfo) ValidateMetricsHeaders() error {
 	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
-	if checkSupportedContentType[ri.ContentType] {
+	if IsContentTypeSupported(ri.ContentType) {
 		return nil
 	} else {
 		return ErrInvalidContentType
@@ -140,7 +131,7 @@ func (ri *RequestInfo) ValidateLogsHeaders() error {
 	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
-	if checkSupportedContentType[ri.ContentType] {
+	if IsContentTypeSupported(ri.ContentType) {
 		return nil
 	} else {
 		return ErrInvalidContentType

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -43,6 +43,11 @@ var (
 	}
 )
 
+// List of HTTP Content Types supported for OTLP ingest.
+func GetSupportedContentTypes() []string {
+	return supportedContentTypes
+}
+
 // Check whether we support a given HTTP Content Type for OTLP.
 func IsContentTypeSupported(contentType string) bool {
 	for _, supportedType := range supportedContentTypes {

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -113,11 +113,10 @@ func (ri *RequestInfo) ValidateTracesHeaders() error {
 	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
-	if IsContentTypeSupported(ri.ContentType) {
-		return nil
-	} else {
+	if !IsContentTypeSupported(ri.ContentType) {
 		return ErrInvalidContentType
 	}
+	return nil // no error, headers passed all the validations
 }
 
 // ValidateMetricsHeaders validates required headers/metadata for a metric OTLP request
@@ -128,11 +127,10 @@ func (ri *RequestInfo) ValidateMetricsHeaders() error {
 	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
-	if IsContentTypeSupported(ri.ContentType) {
-		return nil
-	} else {
+	if !IsContentTypeSupported(ri.ContentType) {
 		return ErrInvalidContentType
 	}
+	return nil // no error, headers passed all the validations
 }
 
 // ValidateLogsHeaders validates required headers/metadata for a logs OTLP request
@@ -143,11 +141,10 @@ func (ri *RequestInfo) ValidateLogsHeaders() error {
 	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
-	if IsContentTypeSupported(ri.ContentType) {
-		return nil
-	} else {
+	if !IsContentTypeSupported(ri.ContentType) {
 		return ErrInvalidContentType
 	}
+	return nil
 }
 
 // GetRequestInfoFromGrpcMetadata parses relevant gRPC metadata from an incoming request context

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -164,11 +164,11 @@ func TestValidateMetricsHeaders(t *testing.T) {
 		{name: "new API key and missing dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
 		{name: "missing API key", apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
 		{name: "missing content-type", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
-		{name: "application/json content-type", apikey: "apikey", dataset: "dataset", contentType: "application/json", err: ErrInvalidContentType},
 		{name: "application/javascript content-type", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
 		{name: "application/xml content-type", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
 		{name: "application/octet-stream content-type", apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
 		{name: "text-plain content type", apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
+		{name: "application/json content-type", apikey: "apikey", dataset: "dataset", contentType: "application/json", err: nil},
 		{name: "application/protobuf content-type", apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
 		{name: "application/x-protobuf content-type", apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
 	}

--- a/otlp/common_testhelpers.go
+++ b/otlp/common_testhelpers.go
@@ -1,0 +1,86 @@
+package otlp
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/klauspost/compress/zstd"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/runtime/protoiface"
+)
+
+// The collector<signal>.Export<signal>ServiceRequest structs generated from proto
+// definitions each implment the interfaces embedded here. This combined interface
+// allows for a single transformer function to receive a request struct
+// and return a request serialized in a variety of formats.
+type marshalableOtlpRequest interface {
+	protoiface.MessageV1      // to protobuf
+	protoreflect.ProtoMessage // to protojson
+}
+
+// transforms an OTLP signal request proto struct into a supported Content-Type
+// and then encoded appropriately for an HTTP request
+func prepareOtlpRequestHttpBody(req marshalableOtlpRequest, contentType string, encoding string) (string, error) {
+	var bodyBytes []byte
+	var err error
+	switch contentType {
+	case "application/protobuf", "application/x-protobuf":
+		bodyBytes, err = proto.Marshal(req)
+		if err != nil {
+			return "", err
+		}
+	case "application/json":
+		bodyBytes, err = protojson.Marshal(req)
+		if err != nil {
+			return "", err
+		}
+	default:
+		return "", errors.New("Unknown content-type '" + contentType + "' given for test case. This probably won't go well.")
+	}
+
+	body, err := encodeBody(bodyBytes, encoding)
+	return body, err
+}
+
+// Encode a slice of bytes destined to be the body of an HTTP request
+// to a target encoding.
+func encodeBody(body []byte, encoding string) (string, error) {
+	encodedBytes := new(bytes.Buffer)
+	switch encoding {
+	case "":
+		encodedBytes.Write(body)
+	case "gzip":
+		w := gzip.NewWriter(encodedBytes)
+		w.Write(body)
+		w.Close()
+	case "zstd":
+		w, _ := zstd.NewWriter(encodedBytes)
+		w.Write(body)
+		w.Close()
+	default:
+		return "", errors.New("Unknown content-encoding '" + encoding + "' given for test case. This probably won't go well.")
+	}
+	return encodedBytes.String(), nil
+}
+
+// Removes "application/" prefix from Content Type values to reduce the
+// nesting of test case name in verbose test output and results.
+// e.g. "application/x-protobuf" -> "x-protobuf"
+func testCaseNameForContentType(contentType string) string {
+	return strings.Split(contentType, "/")[1]
+}
+
+// Return a friendlier string for the test cases where Content Encoding
+// is ambiguous, e.g. no encoding given is blank, so we give it a
+// meaningful name here.
+func testCaseNameForEncoding(encoding string) string {
+	if encoding == "" {
+		return "no encoding given assume uncompressed"
+	} else {
+		return encoding
+	}
+}

--- a/otlp/errors.go
+++ b/otlp/errors.go
@@ -3,6 +3,7 @@ package otlp
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -15,7 +16,7 @@ type OTLPError struct {
 }
 
 var (
-	ErrInvalidContentType   = OTLPError{"invalid content-type - only 'application/protobuf' is supported", http.StatusNotImplemented, codes.Unimplemented}
+	ErrInvalidContentType   = OTLPError{"unsupported content-type, valid types are: " + strings.Join(GetSupportedContentTypes(), ", "), http.StatusUnsupportedMediaType, codes.Unimplemented}
 	ErrFailedParseBody      = OTLPError{"failed to parse OTLP request body", http.StatusBadRequest, codes.Internal}
 	ErrMissingAPIKeyHeader  = OTLPError{"missing 'x-honeycomb-team' header", http.StatusUnauthorized, codes.Unauthenticated}
 	ErrMissingDatasetHeader = OTLPError{"missing 'x-honeycomb-dataset' header", http.StatusUnauthorized, codes.Unauthenticated}

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -78,7 +78,7 @@ func TestTranslateLogsRequest(t *testing.T) {
 		expectedDataset string
 	}{
 		{
-			Name: "Legacy",
+			Name: "Classic",
 			ri: RequestInfo{
 				ApiKey:      "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
 				Dataset:     "legacy-dataset",
@@ -87,7 +87,7 @@ func TestTranslateLogsRequest(t *testing.T) {
 			expectedDataset: "legacy-dataset",
 		},
 		{
-			Name: "NonLegacy",
+			Name: "E&S",
 			ri: RequestInfo{
 				ApiKey:      "abc123DEF456ghi789jklm",
 				Dataset:     "legacy-dataset",
@@ -185,7 +185,7 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 		expectedDataset string
 	}{
 		{
-			Name: "Legacy",
+			Name: "Classic",
 			ri: RequestInfo{
 				ApiKey:  "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
 				Dataset: "legacy-dataset",
@@ -193,7 +193,7 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 			expectedDataset: "legacy-dataset",
 		},
 		{
-			Name: "NonLegacy",
+			Name: "E&S",
 			ri: RequestInfo{
 				ApiKey:  "abc123DEF456ghi789jklm",
 				Dataset: "legacy-dataset",

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -111,7 +111,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 		expectedDataset string
 	}{
 		{
-			Name: "Legacy",
+			Name: "Classic",
 			ri: RequestInfo{
 				ApiKey:      "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
 				Dataset:     "legacy-dataset",
@@ -120,7 +120,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 			expectedDataset: "legacy-dataset",
 		},
 		{
-			Name: "NonLegacy",
+			Name: "E&S",
 			ri: RequestInfo{
 				ApiKey:      "abc123DEF456ghi789jklm",
 				Dataset:     "legacy-dataset",
@@ -391,7 +391,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 		expectedDataset string
 	}{
 		{
-			Name: "Legacy",
+			Name: "Classic",
 			ri: RequestInfo{
 				ApiKey:  "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
 				Dataset: "legacy-dataset",
@@ -399,7 +399,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 			expectedDataset: "legacy-dataset",
 		},
 		{
-			Name: "NonLegacy",
+			Name: "E&S",
 			ri: RequestInfo{
 				ApiKey:  "abc123DEF456ghi789jklm",
 				Dataset: "legacy-dataset",

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/honeycombio/husky/test"
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -501,86 +502,68 @@ func TestTranslateLegacyHttpTraceRequest(t *testing.T) {
 		}},
 	}
 
-	for _, contentType := range []string{"application/protobuf", "application/json"} {
-		var bodyBytes []byte
-		var err error
-		if contentType == "application/protobuf" {
-			bodyBytes, err = proto.Marshal(req)
-		} else {
-			bodyBytes, err = protojson.Marshal(req)
-		}
-		assert.Nil(t, err)
+	for _, testCaseContentType := range GetSupportedContentTypes() {
+		t.Run(testCaseNameForContentType(testCaseContentType), func(t *testing.T) {
+			for _, testCaseContentEncoding := range GetSupportedContentEncodings() {
+				t.Run(testCaseNameForEncoding(testCaseContentEncoding), func(t *testing.T) {
 
-		for _, encoding := range []string{"", "gzip", "zstd"} {
-			t.Run(encoding, func(t *testing.T) {
-				buf := new(bytes.Buffer)
-				switch encoding {
-				case "gzip":
-					w := gzip.NewWriter(buf)
-					w.Write(bodyBytes)
-					w.Close()
-				case "zstd":
-					w, _ := zstd.NewWriter(buf)
-					w.Write(bodyBytes)
-					w.Close()
-				default:
-					buf.Write(bodyBytes)
-				}
+					ri := RequestInfo{
+						ApiKey:          "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+						Dataset:         "legacy-dataset",
+						ContentType:     testCaseContentType,
+						ContentEncoding: testCaseContentEncoding,
+					}
 
-				body := io.NopCloser(strings.NewReader(buf.String()))
-				ri := RequestInfo{
-					ApiKey:          "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
-					Dataset:         "legacy-dataset",
-					ContentType:     contentType,
-					ContentEncoding: encoding,
-				}
+					body, err := prepareOtlpRequestHttpBody(req, testCaseContentType, testCaseContentEncoding)
+					require.NoError(t, err, "Womp womp. Ought to have been able to turn the OTLP trace request into an HTTP body.")
 
-				result, err := TranslateTraceRequestFromReader(body, ri)
-				assert.Nil(t, err)
-				assert.Equal(t, proto.Size(req), result.RequestSize)
-				assert.Equal(t, 1, len(result.Batches))
-				batch := result.Batches[0]
-				assert.Equal(t, "legacy-dataset", batch.Dataset)
-				assert.Equal(t, proto.Size(req.ResourceSpans[0]), batch.SizeBytes)
-				events := batch.Events
-				assert.Equal(t, 3, len(events))
+					result, err := TranslateTraceRequestFromReader(io.NopCloser(strings.NewReader(body)), ri)
+					assert.Nil(t, err)
+					assert.Equal(t, proto.Size(req), result.RequestSize)
+					assert.Equal(t, 1, len(result.Batches))
+					batch := result.Batches[0]
+					assert.Equal(t, "legacy-dataset", batch.Dataset)
+					assert.Equal(t, proto.Size(req.ResourceSpans[0]), batch.SizeBytes)
+					events := batch.Events
+					assert.Equal(t, 3, len(events))
 
-				// span
-				ev := events[0]
-				assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
-				assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-				assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.span_id"])
-				assert.Equal(t, "client", ev.Attributes["type"])
-				assert.Equal(t, "client", ev.Attributes["span.kind"])
-				assert.Equal(t, "test_span", ev.Attributes["name"])
-				assert.Equal(t, "my-service", ev.Attributes["service.name"])
-				assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
-				assert.Equal(t, int(trace.Status_STATUS_CODE_OK), ev.Attributes["status_code"])
-				assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
-				assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+					// span
+					ev := events[0]
+					assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
+					assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+					assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.span_id"])
+					assert.Equal(t, "client", ev.Attributes["type"])
+					assert.Equal(t, "client", ev.Attributes["span.kind"])
+					assert.Equal(t, "test_span", ev.Attributes["name"])
+					assert.Equal(t, "my-service", ev.Attributes["service.name"])
+					assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
+					assert.Equal(t, int(trace.Status_STATUS_CODE_OK), ev.Attributes["status_code"])
+					assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
+					assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 
-				// event
-				ev = events[1]
-				assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-				assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
-				assert.Equal(t, "span_event", ev.Attributes["name"])
-				assert.Equal(t, "test_span", ev.Attributes["parent_name"])
-				assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
-				assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
-				assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+					// event
+					ev = events[1]
+					assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+					assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+					assert.Equal(t, "span_event", ev.Attributes["name"])
+					assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+					assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
+					assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
+					assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 
-				// link
-				ev = events[2]
-				assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-				assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
-				assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])
-				assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.Attributes["trace.link.span_id"])
-				assert.Equal(t, "test_span", ev.Attributes["parent_name"])
-				assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
-				assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
-				assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-			})
-		}
+					// link
+					ev = events[2]
+					assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+					assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+					assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])
+					assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.Attributes["trace.link.span_id"])
+					assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+					assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
+					assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
+					assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+				})
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Enabling support for all the OTLP content types. The ingest for metrics is still handled elsewhere at the moment, but that process uses husky's header validation before proceeding, so allowing JSON needs to happen here first.


## Short description of the changes

* Refactored how supported content types are checked. A list of supported types is declared once and public function is provided to check for the presence of a given type in the supported list.
  * A note here that all three signals have the same validation implementation which I suspect may remain true for husky's level of abstraction. We could consider consolidating them down to one function.
* Bonus: included a correction to the HTTP error we return when a content type is not supported: [415 Unsupported Media Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415) instead of [501 Not Implemented](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501). If we don't support a content type, that's not a server side error.
* Refactored ingestion tests into loop-driven test cases of Classic/E&S, content types, and content encodings. Removed some tests that were duplicates of others.