### PR TITLE
[fix] unconsolidate header validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,9 @@ jobs:
       - restore_cache:
           keys:
             - v1-go-mod-{{ checksum "go.sum" }}
-      - run: go test -v ./...
+      - run: make test
+      - store_test_results:
+          path: ./unit-tests.xml
       - save_cache:
           key: v1-go-mod-{{ checksum "go.sum" }}
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+unit-tests.xml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test
+test:
+ifeq (, $(shell which gotestsum))
+	@echo " ***"
+	@echo "Runing with standard go test because gotestsum was not found on PATH. Consider installing gotestsum for friendlier test output!"
+	@echo " ***"
+	go test ./...
+else
+	gotestsum --junitfile unit-tests.xml --format testname
+endif

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -138,9 +138,6 @@ func (ri *RequestInfo) ValidateLogsHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
-	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
-		return ErrMissingDatasetHeader
-	}
 	if !IsContentTypeSupported(ri.ContentType) {
 		return ErrInvalidContentType
 	}

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -105,35 +105,8 @@ func (ri RequestInfo) hasLegacyKey() bool {
 	return legacyApiKeyPattern.MatchString(ri.ApiKey)
 }
 
-// ValidateTracesHeaders checks for required headers/metadata for all OTLP requests
-// and specific to Traces.
+// ValidateTracesHeaders validates required headers/metadata for a trace OTLP request
 func (ri *RequestInfo) ValidateTracesHeaders() error {
-	// validations specific to traces
-	// - none for now
-	// validations common for all OTLP requests
-	return validateHeaders(ri)
-}
-
-// ValidateMetricsHeaders checks for required headers/metadata for all OTLP requests
-// and specific to Metrics.
-func (ri *RequestInfo) ValidateMetricsHeaders() error {
-	// validations specific to metrics
-	// - none for now
-	// validations common for all OTLP requests
-	return validateHeaders(ri)
-}
-
-// ValidateLogsHeaders checks for required headers/metadata for all OTLP requests
-// and specific to Logs.
-func (ri *RequestInfo) ValidateLogsHeaders() error {
-	// validations specific to logs
-	// - none for now
-	// validations common for all OTLP requests
-	return validateHeaders(ri)
-}
-
-// Header validation that is common across OTLP signal requests.
-func validateHeaders(ri *RequestInfo) error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
@@ -144,6 +117,34 @@ func validateHeaders(ri *RequestInfo) error {
 		return ErrInvalidContentType
 	}
 	return nil // no error, headers passed all the validations
+}
+
+// ValidateMetricsHeaders validates required headers/metadata for a metric OTLP request
+func (ri *RequestInfo) ValidateMetricsHeaders() error {
+	if len(ri.ApiKey) == 0 {
+		return ErrMissingAPIKeyHeader
+	}
+	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
+		return ErrMissingDatasetHeader
+	}
+	if !IsContentTypeSupported(ri.ContentType) {
+		return ErrInvalidContentType
+	}
+	return nil // no error, headers passed all the validations
+}
+
+// ValidateLogsHeaders validates required headers/metadata for a logs OTLP request
+func (ri *RequestInfo) ValidateLogsHeaders() error {
+	if len(ri.ApiKey) == 0 {
+		return ErrMissingAPIKeyHeader
+	}
+	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
+		return ErrMissingDatasetHeader
+	}
+	if !IsContentTypeSupported(ri.ContentType) {
+		return ErrInvalidContentType
+	}
+	return nil
 }
 
 // GetRequestInfoFromGrpcMetadata parses relevant gRPC metadata from an incoming request context

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -124,7 +124,7 @@ func (ri *RequestInfo) ValidateMetricsHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
-	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
+	if len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
 	if !IsContentTypeSupported(ri.ContentType) {

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -125,29 +125,38 @@ func TestAddAttributesToMap(t *testing.T) {
 
 func TestValidateTracesHeaders(t *testing.T) {
 	testCases := []struct {
+		name        string
 		apikey      string
 		dataset     string
 		contentType string
 		err         error
 	}{
-		{apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
-		{apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
-		{apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
-		{apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
-		{apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
-		{apikey: "apikey", dataset: "dataset", contentType: "application/json", err: nil},
+		{name: "no key, no dataset", apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
+		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
+		{name: "classic/no dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		{name: "classic/dataset present", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
+		{name: "E&S/dataset present", apikey: "abc123DEF456ghi789jklm", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
+		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
+		{name: "content-type/xml", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
+		{name: "content-type/octet-stream", apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
+		{name: "content-type/text-plain", apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
+		{name: "content-type/json", apikey: "apikey", dataset: "dataset", contentType: "application/json", err: nil},
+		{name: "content-type/protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "content-type/x-protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
 	}
 
 	for _, tc := range testCases {
-		ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
-		err := ri.ValidateTracesHeaders()
-		assert.Equal(t, tc.err, err)
+		t.Run(tc.name, func(t *testing.T) {
+			ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
+			err := ri.ValidateTracesHeaders()
+			if tc.err != nil {
+				assert.EqualError(t, tc.err, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 
@@ -159,25 +168,68 @@ func TestValidateMetricsHeaders(t *testing.T) {
 		contentType string
 		err         error
 	}{
-		{name: "missing API key and missing dataset", apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
-		{name: "legacy API key and missing dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
-		{name: "new API key and missing dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "missing API key", apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
-		{name: "missing content-type", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
-		{name: "application/javascript content-type", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
-		{name: "application/xml content-type", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
-		{name: "application/octet-stream content-type", apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
-		{name: "text-plain content type", apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
-		{name: "application/json content-type", apikey: "apikey", dataset: "dataset", contentType: "application/json", err: nil},
-		{name: "application/protobuf content-type", apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "application/x-protobuf content-type", apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
+		{name: "no key, no dataset", apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
+		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
+		{name: "classic/no dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		{name: "classic/dataset present", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
+		{name: "E&S/dataset present", apikey: "abc123DEF456ghi789jklm", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
+		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
+		{name: "content-type/xml", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
+		{name: "content-type/octet-stream", apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
+		{name: "content-type/text-plain", apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
+		{name: "content-type/json", apikey: "apikey", dataset: "dataset", contentType: "application/json", err: nil},
+		{name: "content-type/protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "content-type/x-protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
 			err := ri.ValidateMetricsHeaders()
-			assert.Equal(t, tc.err, err)
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateLogsHeaders(t *testing.T) {
+	testCases := []struct {
+		name        string
+		apikey      string
+		dataset     string
+		contentType string
+		err         error
+	}{
+		{name: "no key, no dataset", apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
+		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
+		{name: "classic/no dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		{name: "classic/dataset present", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
+		{name: "E&S/dataset present", apikey: "abc123DEF456ghi789jklm", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
+		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
+		{name: "content-type/xml", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
+		{name: "content-type/octet-stream", apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
+		{name: "content-type/text-plain", apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
+		{name: "content-type/json", apikey: "apikey", dataset: "dataset", contentType: "application/json", err: nil},
+		{name: "content-type/protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "content-type/x-protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
+			err := ri.ValidateLogsHeaders()
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -207,9 +207,11 @@ func TestValidateLogsHeaders(t *testing.T) {
 	}{
 		{name: "no key, no dataset", apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
 		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
-		{name: "classic/no dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
+		// logs will use dataset header if present, but log ingest will also use service.name in the data
+		// and we will have a sensible default if neither are present, so a missing dataset header is not an error here
+		{name: "classic/no dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "application/protobuf", err: nil},
 		{name: "classic/dataset present", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
+		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
 		{name: "E&S/dataset present", apikey: "abc123DEF456ghi789jklm", dataset: "dataset", contentType: "application/protobuf", err: nil},
 		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
 		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},


### PR DESCRIPTION
## Which problem is this PR solving?

Our request header validation rules differ between OTLP Logs, Metrics, and Traces. We'll need to undo the consolidation of the validation logic done in #121. 🤭 

## Short description of the changes

- [x] update tests to demonstrate the problem:
  * Metrics didn't cover "E&S key, no dataset" case.
  * There didn't appear to be tests for validating log requests.
- [x] make those tests pass!


