### PR TITLE
For logs, fall back to dataset if service is unknown

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -236,22 +236,16 @@ func getDataset(ri RequestInfo, attrs map[string]interface{}) string {
 
 func getLogsDataset(ri RequestInfo, attrs map[string]interface{}) string {
 	var dataset string
-	if ri.hasLegacyKey() {
-		dataset = ri.Dataset
-	} else {
-		serviceName, ok := attrs["service.name"].(string)
-		if !ok ||
-			strings.TrimSpace(serviceName) == "" ||
-			strings.HasPrefix(serviceName, "unknown_service") {
-			if strings.TrimSpace(ri.Dataset) == "" {
-				// In practice, this won't actually get hit, because we error on missing dataset header
-				dataset = unknownLogSource
-			} else {
-				dataset = ri.Dataset
-			}
+	serviceName, ok := attrs["service.name"].(string)
+	if !ok || strings.TrimSpace(serviceName) == "" || strings.HasPrefix(serviceName, "unknown_service") {
+		if strings.TrimSpace(ri.Dataset) == "" {
+			// In practice, this won't actually get hit, because we error on missing dataset header
+			dataset = unknownLogSource
 		} else {
-			dataset = strings.TrimSpace(serviceName)
+			dataset = ri.Dataset
 		}
+	} else {
+		dataset = strings.TrimSpace(serviceName)
 	}
 	return dataset
 }

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -239,7 +239,6 @@ func getLogsDataset(ri RequestInfo, attrs map[string]interface{}) string {
 	serviceName, ok := attrs["service.name"].(string)
 	if !ok || strings.TrimSpace(serviceName) == "" || strings.HasPrefix(serviceName, "unknown_service") {
 		if strings.TrimSpace(ri.Dataset) == "" {
-			// In practice, this won't actually get hit, because we error on missing dataset header
 			dataset = unknownLogSource
 		} else {
 			dataset = ri.Dataset

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -233,6 +233,27 @@ func getDataset(ri RequestInfo, attrs map[string]interface{}) string {
 	return dataset
 }
 
+func getLogsDataset(ri RequestInfo, attrs map[string]interface{}) string {
+	var dataset string
+	if ri.hasLegacyKey() {
+		dataset = ri.Dataset
+	} else {
+		serviceName, ok := attrs["service.name"].(string)
+		if !ok ||
+			strings.TrimSpace(serviceName) == "" ||
+			strings.HasPrefix(serviceName, "unknown_service") {
+			if strings.TrimSpace(ri.Dataset) == "" {
+				dataset = "unknown_logs_source"
+			} else {
+				dataset = ri.Dataset
+			}
+		} else {
+			dataset = strings.TrimSpace(serviceName)
+		}
+	}
+	return dataset
+}
+
 func getValue(value *common.AnyValue) interface{} {
 	switch value.Value.(type) {
 	case *common.AnyValue_StringValue:

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -31,6 +31,7 @@ const (
 	contentEncodingHeader    = "content-encoding"
 	gRPCAcceptEncodingHeader = "grpc-accept-encoding"
 	defaultServiceName       = "unknown_service"
+	unknownLogSource         = "unknown_log_source"
 )
 
 var (
@@ -243,7 +244,8 @@ func getLogsDataset(ri RequestInfo, attrs map[string]interface{}) string {
 			strings.TrimSpace(serviceName) == "" ||
 			strings.HasPrefix(serviceName, "unknown_service") {
 			if strings.TrimSpace(ri.Dataset) == "" {
-				dataset = "unknown_logs_source"
+				// In practice, this won't actually get hit, because we error on missing dataset header
+				dataset = unknownLogSource
 			} else {
 				dataset = ri.Dataset
 			}

--- a/otlp/common_testhelpers.go
+++ b/otlp/common_testhelpers.go
@@ -5,12 +5,18 @@ import (
 	"compress/gzip"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/golang/protobuf/proto"
+	common "github.com/honeycombio/husky/proto/otlp/common/v1"
+	resource "github.com/honeycombio/husky/proto/otlp/resource/v1"
 	"github.com/klauspost/compress/zstd"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/runtime/protoiface"
+
+	collectorlogs "github.com/honeycombio/husky/proto/otlp/collector/logs/v1"
+	logs "github.com/honeycombio/husky/proto/otlp/logs/v1"
 )
 
 // The collector<signal>.Export<signal>ServiceRequest structs generated from proto
@@ -83,4 +89,55 @@ func testCaseNameForEncoding(encoding string) string {
 	} else {
 		return encoding
 	}
+}
+
+func buildExportLogsServiceRequest(traceID []byte, spanID []byte, startTimestamp time.Time, testServiceName string) *collectorlogs.ExportLogsServiceRequest {
+	req := &collectorlogs.ExportLogsServiceRequest{
+		ResourceLogs: []*logs.ResourceLogs{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "resource_attr",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
+					},
+				}, {
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: testServiceName},
+					},
+				}},
+			},
+			ScopeLogs: []*logs.ScopeLogs{{
+				Scope: &common.InstrumentationScope{
+					Name:    "instr_scope_name",
+					Version: "instr_scope_version",
+					Attributes: []*common.KeyValue{
+						{
+							Key: "scope_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
+							},
+						},
+					},
+				},
+				LogRecords: []*logs.LogRecord{{
+					TraceId:        traceID,
+					SpanId:         spanID,
+					TimeUnixNano:   uint64(startTimestamp.Nanosecond()),
+					SeverityText:   "test_severity_text",
+					SeverityNumber: logs.SeverityNumber_SEVERITY_NUMBER_DEBUG,
+					Attributes: []*common.KeyValue{
+						{
+							Key: "span_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
+							},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+
+	return req
 }

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -33,7 +33,7 @@ func TranslateLogsRequest(request *collectorLogs.ExportLogsServiceRequest, ri Re
 	for _, resourceLog := range request.ResourceLogs {
 		var events []Event
 		resourceAttrs := getResourceAttributes(resourceLog.Resource)
-		dataset := getDataset(ri, resourceAttrs)
+		dataset := getLogsDataset(ri, resourceAttrs)
 
 		for _, scopeLog := range resourceLog.ScopeLogs {
 			scopeAttrs := getScopeAttributes(scopeLog.Scope)

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -336,7 +336,7 @@ func TestTranslateHttpLogsRequestWithoutServiceAndWithoutDataset(t *testing.T) {
 				ApiKey:  "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
 				Dataset: "",
 			},
-			expectedDataset: unknownLogSource, // we'll get an error before this...
+			expectedDataset: unknownLogSource,
 		},
 		{
 			Name: "E&S",
@@ -344,7 +344,7 @@ func TestTranslateHttpLogsRequestWithoutServiceAndWithoutDataset(t *testing.T) {
 				ApiKey:  "abc123DEF456ghi789jklm",
 				Dataset: "",
 			},
-			expectedDataset: unknownLogSource, // we'll get an error before this...
+			expectedDataset: unknownLogSource,
 		},
 	}
 

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -25,52 +25,7 @@ func TestTranslateLogsRequest(t *testing.T) {
 
 	testServiceName := "my-service"
 
-	req := &collectorlogs.ExportLogsServiceRequest{
-		ResourceLogs: []*logs.ResourceLogs{{
-			Resource: &resource.Resource{
-				Attributes: []*common.KeyValue{{
-					Key: "resource_attr",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
-					},
-				}, {
-					Key: "service.name",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: testServiceName},
-					},
-				}},
-			},
-			ScopeLogs: []*logs.ScopeLogs{{
-				Scope: &common.InstrumentationScope{
-					Name:    "library-name",
-					Version: "library-version",
-					Attributes: []*common.KeyValue{
-						{
-							Key: "scope_attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
-							},
-						},
-					},
-				},
-				LogRecords: []*logs.LogRecord{{
-					TraceId:        traceID,
-					SpanId:         spanID,
-					TimeUnixNano:   uint64(startTimestamp.Nanosecond()),
-					SeverityText:   "test_severity_text",
-					SeverityNumber: logs.SeverityNumber_SEVERITY_NUMBER_DEBUG,
-					Attributes: []*common.KeyValue{
-						{
-							Key: "span_attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
-							},
-						},
-					},
-				}},
-			}},
-		}},
-	}
+	req := buildExportLogsServiceRequest(traceID, spanID, startTimestamp, testServiceName)
 
 	testCases := []struct {
 		Name            string
@@ -132,52 +87,7 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 
 	testServiceName := "my-service"
 
-	req := &collectorlogs.ExportLogsServiceRequest{
-		ResourceLogs: []*logs.ResourceLogs{{
-			Resource: &resource.Resource{
-				Attributes: []*common.KeyValue{{
-					Key: "resource_attr",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
-					},
-				}, {
-					Key: "service.name",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: testServiceName},
-					},
-				}},
-			},
-			ScopeLogs: []*logs.ScopeLogs{{
-				Scope: &common.InstrumentationScope{
-					Name:    "instr_scope_name",
-					Version: "instr_scope_version",
-					Attributes: []*common.KeyValue{
-						{
-							Key: "scope_attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
-							},
-						},
-					},
-				},
-				LogRecords: []*logs.LogRecord{{
-					TraceId:        traceID,
-					SpanId:         spanID,
-					TimeUnixNano:   uint64(startTimestamp.Nanosecond()),
-					SeverityText:   "test_severity_text",
-					SeverityNumber: logs.SeverityNumber_SEVERITY_NUMBER_DEBUG,
-					Attributes: []*common.KeyValue{
-						{
-							Key: "span_attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
-							},
-						},
-					},
-				}},
-			}},
-		}},
-	}
+	req := buildExportLogsServiceRequest(traceID, spanID, startTimestamp, testServiceName)
 
 	testCases := []struct {
 		Name            string
@@ -256,52 +166,7 @@ func TestTranslateHttpLogsRequestWithServiceNameAndDataset(t *testing.T) {
 	testServiceName := "my-service"
 	testSpecifiedDatasetName := "my-dataset-name"
 
-	req := &collectorlogs.ExportLogsServiceRequest{
-		ResourceLogs: []*logs.ResourceLogs{{
-			Resource: &resource.Resource{
-				Attributes: []*common.KeyValue{{
-					Key: "resource_attr",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
-					},
-				}, {
-					Key: "service.name",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: testServiceName},
-					},
-				}},
-			},
-			ScopeLogs: []*logs.ScopeLogs{{
-				Scope: &common.InstrumentationScope{
-					Name:    "instr_scope_name",
-					Version: "instr_scope_version",
-					Attributes: []*common.KeyValue{
-						{
-							Key: "scope_attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
-							},
-						},
-					},
-				},
-				LogRecords: []*logs.LogRecord{{
-					TraceId:        traceID,
-					SpanId:         spanID,
-					TimeUnixNano:   uint64(startTimestamp.Nanosecond()),
-					SeverityText:   "test_severity_text",
-					SeverityNumber: logs.SeverityNumber_SEVERITY_NUMBER_DEBUG,
-					Attributes: []*common.KeyValue{
-						{
-							Key: "span_attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
-							},
-						},
-					},
-				}},
-			}},
-		}},
-	}
+	req := buildExportLogsServiceRequest(traceID, spanID, startTimestamp, testServiceName)
 
 	testCases := []struct {
 		Name            string
@@ -380,52 +245,7 @@ func TestTranslateHttpLogsRequestWithDatasetButNoServiceName(t *testing.T) {
 	testServiceName := "unknown_service"
 	testSpecifiedDatasetName := "my-logs-source"
 
-	req := &collectorlogs.ExportLogsServiceRequest{
-		ResourceLogs: []*logs.ResourceLogs{{
-			Resource: &resource.Resource{
-				Attributes: []*common.KeyValue{{
-					Key: "resource_attr",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
-					},
-				}, {
-					Key: "service.name",
-					Value: &common.AnyValue{
-						Value: &common.AnyValue_StringValue{StringValue: testServiceName},
-					},
-				}},
-			},
-			ScopeLogs: []*logs.ScopeLogs{{
-				Scope: &common.InstrumentationScope{
-					Name:    "instr_scope_name",
-					Version: "instr_scope_version",
-					Attributes: []*common.KeyValue{
-						{
-							Key: "scope_attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
-							},
-						},
-					},
-				},
-				LogRecords: []*logs.LogRecord{{
-					TraceId:        traceID,
-					SpanId:         spanID,
-					TimeUnixNano:   uint64(startTimestamp.Nanosecond()),
-					SeverityText:   "test_severity_text",
-					SeverityNumber: logs.SeverityNumber_SEVERITY_NUMBER_DEBUG,
-					Attributes: []*common.KeyValue{
-						{
-							Key: "span_attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
-							},
-						},
-					},
-				}},
-			}},
-		}},
-	}
+	req := buildExportLogsServiceRequest(traceID, spanID, startTimestamp, testServiceName)
 
 	testCases := []struct {
 		Name            string

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -496,7 +496,7 @@ func TestTranslateHttpLogsRequestWithDatasetButNoServiceName(t *testing.T) {
 	}
 }
 
-func TestTranslateNonServiceHttpLogsWithoutDatasetRequest(t *testing.T) {
+func TestTranslateHttpLogsRequestWithoutServiceAndWithoutDataset(t *testing.T) {
 	testCases := []struct {
 		Name            string
 		ri              RequestInfo

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -53,7 +53,6 @@ func TestTranslateLogsRequest(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.Name, func(t *testing.T) {
-
 			result, err := TranslateLogsRequest(req, tC.ri)
 			assert.Nil(t, err)
 			assert.Equal(t, proto.Size(req), result.RequestSize)
@@ -158,7 +157,7 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 	}
 }
 
-func TestTranslateHttpLogsRequestWithServiceNameAndDataset(t *testing.T) {
+func TestLogtWithServiceNameAndDataset(t *testing.T) {
 	traceID := test.RandomBytes(16)
 	spanID := test.RandomBytes(8)
 	startTimestamp := time.Now()
@@ -206,29 +205,8 @@ func TestTranslateHttpLogsRequestWithServiceNameAndDataset(t *testing.T) {
 
 							result, err := TranslateLogsRequestFromReader(io.NopCloser(strings.NewReader(body)), tC.ri)
 							require.NoError(t, err)
-							assert.Equal(t, proto.Size(req), result.RequestSize)
-							assert.Equal(t, 1, len(result.Batches))
 							batch := result.Batches[0]
 							assert.Equal(t, tC.expectedDataset, batch.Dataset)
-							assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
-							events := batch.Events
-							assert.Equal(t, 1, len(events))
-
-							ev := events[0]
-							assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
-							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
-							assert.Equal(t, "log", ev.Attributes["meta.signal_type"])
-							assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
-							assert.Equal(t, uint32(0), ev.Attributes["flags"])
-							assert.Equal(t, "test_severity_text", ev.Attributes["severity_text"])
-							assert.Equal(t, "debug", ev.Attributes["severity"])
-							assert.Equal(t, testServiceName, ev.Attributes["service.name"])
-							assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
-							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-							assert.Equal(t, "instr_scope_name", ev.Attributes["library.name"])
-							assert.Equal(t, "instr_scope_version", ev.Attributes["library.version"])
-							assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 						})
 					}
 				})
@@ -285,29 +263,13 @@ func TestTranslateHttpLogsRequestWithDatasetButNoServiceName(t *testing.T) {
 
 							result, err := TranslateLogsRequestFromReader(io.NopCloser(strings.NewReader(body)), tC.ri)
 							require.NoError(t, err)
-							assert.Equal(t, proto.Size(req), result.RequestSize)
-							assert.Equal(t, 1, len(result.Batches))
+
 							batch := result.Batches[0]
 							assert.Equal(t, tC.expectedDataset, batch.Dataset)
-							assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
-							events := batch.Events
-							assert.Equal(t, 1, len(events))
 
+							events := batch.Events
 							ev := events[0]
-							assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
-							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
-							assert.Equal(t, "log", ev.Attributes["meta.signal_type"])
-							assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
-							assert.Equal(t, uint32(0), ev.Attributes["flags"])
-							assert.Equal(t, "test_severity_text", ev.Attributes["severity_text"])
-							assert.Equal(t, "debug", ev.Attributes["severity"])
 							assert.Equal(t, "unknown_service", ev.Attributes["service.name"])
-							assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
-							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-							assert.Equal(t, "instr_scope_name", ev.Attributes["library.name"])
-							assert.Equal(t, "instr_scope_version", ev.Attributes["library.version"])
-							assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 						})
 					}
 				})
@@ -363,29 +325,13 @@ func TestTranslateHttpLogsRequestWithoutServiceAndWithoutDataset(t *testing.T) {
 
 							result, err := TranslateLogsRequestFromReader(io.NopCloser(strings.NewReader(body)), tC.ri)
 							require.NoError(t, err)
-							assert.Equal(t, proto.Size(req), result.RequestSize)
-							assert.Equal(t, 1, len(result.Batches))
+
 							batch := result.Batches[0]
 							assert.Equal(t, tC.expectedDataset, batch.Dataset)
-							assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
-							events := batch.Events
-							assert.Equal(t, 1, len(events))
 
+							events := batch.Events
 							ev := events[0]
-							assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
-							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
-							assert.Equal(t, "log", ev.Attributes["meta.signal_type"])
-							assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
-							assert.Equal(t, uint32(0), ev.Attributes["flags"])
-							assert.Equal(t, "test_severity_text", ev.Attributes["severity_text"])
-							assert.Equal(t, "debug", ev.Attributes["severity"])
 							assert.Equal(t, "unknown_service", ev.Attributes["service.name"])
-							assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
-							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-							assert.Equal(t, "instr_scope_name", ev.Attributes["library.name"])
-							assert.Equal(t, "instr_scope_version", ev.Attributes["library.version"])
-							assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
 						})
 					}
 				})

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -192,22 +192,7 @@ func TestLogtWithServiceNameAndDataset(t *testing.T) {
 		},
 	}
 
-	for _, tC := range testCases {
-		t.Run(tC.Name, func(t *testing.T) {
-			result, err := TranslateLogsRequest(req, tC.ri)
-			assert.Nil(t, err)
-			assert.Equal(t, proto.Size(req), result.RequestSize)
-			assert.Equal(t, 1, len(result.Batches))
-			batch := result.Batches[0]
-			assert.Equal(t, tC.expectedDataset, batch.Dataset)
-			assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
-			events := batch.Events
-			assert.Equal(t, 1, len(events))
-
-			ev := events[0]
-			assert.Equal(t, testServiceName, ev.Attributes["service.name"])
-		})
-	}
+	validateCommonLogThings(testCases, t, req, testServiceName)
 }
 
 func TestTranslateHttpLogsRequestWithDatasetButNoServiceName(t *testing.T) {
@@ -245,22 +230,7 @@ func TestTranslateHttpLogsRequestWithDatasetButNoServiceName(t *testing.T) {
 		},
 	}
 
-	for _, tC := range testCases {
-		t.Run(tC.Name, func(t *testing.T) {
-			result, err := TranslateLogsRequest(req, tC.ri)
-			assert.Nil(t, err)
-			assert.Equal(t, proto.Size(req), result.RequestSize)
-			assert.Equal(t, 1, len(result.Batches))
-			batch := result.Batches[0]
-			assert.Equal(t, tC.expectedDataset, batch.Dataset)
-			assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
-			events := batch.Events
-			assert.Equal(t, 1, len(events))
-
-			ev := events[0]
-			assert.Equal(t, testServiceName, ev.Attributes["service.name"])
-		})
-	}
+	validateCommonLogThings(testCases, t, req, testServiceName)
 }
 
 func TestTranslateHttpLogsRequestWithoutServiceAndWithoutDataset(t *testing.T) {
@@ -297,6 +267,14 @@ func TestTranslateHttpLogsRequestWithoutServiceAndWithoutDataset(t *testing.T) {
 		},
 	}
 
+	validateCommonLogThings(testCases, t, req, testServiceName)
+}
+
+func validateCommonLogThings(testCases []struct {
+	Name            string
+	ri              RequestInfo
+	expectedDataset string
+}, t *testing.T, req *collectorlogs.ExportLogsServiceRequest, testServiceName string) {
 	for _, tC := range testCases {
 		t.Run(tC.Name, func(t *testing.T) {
 			result, err := TranslateLogsRequest(req, tC.ri)

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -84,7 +84,7 @@ func TestTranslateLogsRequest(t *testing.T) {
 				Dataset:     "legacy-dataset",
 				ContentType: "application/protobuf",
 			},
-			expectedDataset: "legacy-dataset",
+			expectedDataset: testServiceName,
 		},
 		{
 			Name: "E&S",
@@ -118,7 +118,7 @@ func TestTranslateLogsRequest(t *testing.T) {
 			assert.Equal(t, uint32(0), ev.Attributes["flags"])
 			assert.Equal(t, "test_severity_text", ev.Attributes["severity_text"])
 			assert.Equal(t, "debug", ev.Attributes["severity"])
-			assert.Equal(t, "my-service", ev.Attributes["service.name"])
+			assert.Equal(t, testServiceName, ev.Attributes["service.name"])
 			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 		})
@@ -190,7 +190,7 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 				ApiKey:  "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
 				Dataset: "legacy-dataset",
 			},
-			expectedDataset: "legacy-dataset",
+			expectedDataset: testServiceName,
 		},
 		{
 			Name: "E&S",
@@ -248,12 +248,13 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 	}
 }
 
-func TestTranslateNonServiceHttpLogsWithDatasetRequest(t *testing.T) {
+func TestTranslateHttpLogsRequestWithServiceNameAndDataset(t *testing.T) {
 	traceID := test.RandomBytes(16)
 	spanID := test.RandomBytes(8)
 	startTimestamp := time.Now()
 
-	testServiceName := "unknown_service"
+	testServiceName := "my-service"
+	testSpecifiedDatasetName := "my-dataset-name"
 
 	req := &collectorlogs.ExportLogsServiceRequest{
 		ResourceLogs: []*logs.ResourceLogs{{
@@ -311,17 +312,141 @@ func TestTranslateNonServiceHttpLogsWithDatasetRequest(t *testing.T) {
 			Name: "Classic",
 			ri: RequestInfo{
 				ApiKey:  "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
-				Dataset: "my-logs-source",
+				Dataset: testSpecifiedDatasetName,
 			},
-			expectedDataset: "my-logs-source",
+			expectedDataset: testServiceName,
 		},
 		{
 			Name: "E&S",
 			ri: RequestInfo{
 				ApiKey:  "abc123DEF456ghi789jklm",
-				Dataset: "my-logs-source",
+				Dataset: testSpecifiedDatasetName,
 			},
-			expectedDataset: "my-logs-source",
+			expectedDataset: testServiceName,
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.Name, func(t *testing.T) {
+			for _, testCaseContentType := range GetSupportedContentTypes() {
+				t.Run(testCaseNameForContentType(testCaseContentType), func(t *testing.T) {
+					for _, testCaseContentEncoding := range GetSupportedContentEncodings() {
+						t.Run(testCaseNameForEncoding(testCaseContentEncoding), func(t *testing.T) {
+
+							tC.ri.ContentType = testCaseContentType
+							tC.ri.ContentEncoding = testCaseContentEncoding
+
+							body, err := prepareOtlpRequestHttpBody(req, testCaseContentType, testCaseContentEncoding)
+							require.NoError(t, err, "Womp womp. Ought to have been able to turn the OTLP log request into an HTTP body.")
+
+							result, err := TranslateLogsRequestFromReader(io.NopCloser(strings.NewReader(body)), tC.ri)
+							require.NoError(t, err)
+							assert.Equal(t, proto.Size(req), result.RequestSize)
+							assert.Equal(t, 1, len(result.Batches))
+							batch := result.Batches[0]
+							assert.Equal(t, tC.expectedDataset, batch.Dataset)
+							assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
+							events := batch.Events
+							assert.Equal(t, 1, len(events))
+
+							ev := events[0]
+							assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
+							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+							assert.Equal(t, "log", ev.Attributes["meta.signal_type"])
+							assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
+							assert.Equal(t, uint32(0), ev.Attributes["flags"])
+							assert.Equal(t, "test_severity_text", ev.Attributes["severity_text"])
+							assert.Equal(t, "debug", ev.Attributes["severity"])
+							assert.Equal(t, testServiceName, ev.Attributes["service.name"])
+							assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
+							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+							assert.Equal(t, "instr_scope_name", ev.Attributes["library.name"])
+							assert.Equal(t, "instr_scope_version", ev.Attributes["library.version"])
+							assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestTranslateHttpLogsRequestWithDatasetButNoServiceName(t *testing.T) {
+	traceID := test.RandomBytes(16)
+	spanID := test.RandomBytes(8)
+	startTimestamp := time.Now()
+
+	testServiceName := "unknown_service"
+	testSpecifiedDatasetName := "my-logs-source"
+
+	req := &collectorlogs.ExportLogsServiceRequest{
+		ResourceLogs: []*logs.ResourceLogs{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "resource_attr",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
+					},
+				}, {
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: testServiceName},
+					},
+				}},
+			},
+			ScopeLogs: []*logs.ScopeLogs{{
+				Scope: &common.InstrumentationScope{
+					Name:    "instr_scope_name",
+					Version: "instr_scope_version",
+					Attributes: []*common.KeyValue{
+						{
+							Key: "scope_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
+							},
+						},
+					},
+				},
+				LogRecords: []*logs.LogRecord{{
+					TraceId:        traceID,
+					SpanId:         spanID,
+					TimeUnixNano:   uint64(startTimestamp.Nanosecond()),
+					SeverityText:   "test_severity_text",
+					SeverityNumber: logs.SeverityNumber_SEVERITY_NUMBER_DEBUG,
+					Attributes: []*common.KeyValue{
+						{
+							Key: "span_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
+							},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+
+	testCases := []struct {
+		Name            string
+		ri              RequestInfo
+		expectedDataset string
+	}{
+		{
+			Name: "Classic",
+			ri: RequestInfo{
+				ApiKey:  "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+				Dataset: testSpecifiedDatasetName,
+			},
+			expectedDataset: testSpecifiedDatasetName,
+		},
+		{
+			Name: "E&S",
+			ri: RequestInfo{
+				ApiKey:  "abc123DEF456ghi789jklm",
+				Dataset: testSpecifiedDatasetName,
+			},
+			expectedDataset: testSpecifiedDatasetName,
 		},
 	}
 

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -248,6 +248,252 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 	}
 }
 
+func TestTranslateNonServiceHttpLogsWithDatasetRequest(t *testing.T) {
+	traceID := test.RandomBytes(16)
+	spanID := test.RandomBytes(8)
+	startTimestamp := time.Now()
+
+	testServiceName := "unknown_service"
+
+	req := &collectorlogs.ExportLogsServiceRequest{
+		ResourceLogs: []*logs.ResourceLogs{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "resource_attr",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
+					},
+				}, {
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: testServiceName},
+					},
+				}},
+			},
+			ScopeLogs: []*logs.ScopeLogs{{
+				Scope: &common.InstrumentationScope{
+					Name:    "instr_scope_name",
+					Version: "instr_scope_version",
+					Attributes: []*common.KeyValue{
+						{
+							Key: "scope_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
+							},
+						},
+					},
+				},
+				LogRecords: []*logs.LogRecord{{
+					TraceId:        traceID,
+					SpanId:         spanID,
+					TimeUnixNano:   uint64(startTimestamp.Nanosecond()),
+					SeverityText:   "test_severity_text",
+					SeverityNumber: logs.SeverityNumber_SEVERITY_NUMBER_DEBUG,
+					Attributes: []*common.KeyValue{
+						{
+							Key: "span_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
+							},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+
+	testCases := []struct {
+		Name            string
+		ri              RequestInfo
+		expectedDataset string
+	}{
+		{
+			Name: "Classic",
+			ri: RequestInfo{
+				ApiKey:  "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+				Dataset: "my-logs-source",
+			},
+			expectedDataset: "my-logs-source",
+		},
+		{
+			Name: "E&S",
+			ri: RequestInfo{
+				ApiKey:  "abc123DEF456ghi789jklm",
+				Dataset: "my-logs-source",
+			},
+			expectedDataset: "my-logs-source",
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.Name, func(t *testing.T) {
+			for _, testCaseContentType := range GetSupportedContentTypes() {
+				t.Run(testCaseNameForContentType(testCaseContentType), func(t *testing.T) {
+					for _, testCaseContentEncoding := range GetSupportedContentEncodings() {
+						t.Run(testCaseNameForEncoding(testCaseContentEncoding), func(t *testing.T) {
+
+							tC.ri.ContentType = testCaseContentType
+							tC.ri.ContentEncoding = testCaseContentEncoding
+
+							body, err := prepareOtlpRequestHttpBody(req, testCaseContentType, testCaseContentEncoding)
+							require.NoError(t, err, "Womp womp. Ought to have been able to turn the OTLP log request into an HTTP body.")
+
+							result, err := TranslateLogsRequestFromReader(io.NopCloser(strings.NewReader(body)), tC.ri)
+							require.NoError(t, err)
+							assert.Equal(t, proto.Size(req), result.RequestSize)
+							assert.Equal(t, 1, len(result.Batches))
+							batch := result.Batches[0]
+							assert.Equal(t, tC.expectedDataset, batch.Dataset)
+							assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
+							events := batch.Events
+							assert.Equal(t, 1, len(events))
+
+							ev := events[0]
+							assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
+							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+							assert.Equal(t, "log", ev.Attributes["meta.signal_type"])
+							assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
+							assert.Equal(t, uint32(0), ev.Attributes["flags"])
+							assert.Equal(t, "test_severity_text", ev.Attributes["severity_text"])
+							assert.Equal(t, "debug", ev.Attributes["severity"])
+							assert.Equal(t, "unknown_service", ev.Attributes["service.name"])
+							assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
+							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+							assert.Equal(t, "instr_scope_name", ev.Attributes["library.name"])
+							assert.Equal(t, "instr_scope_version", ev.Attributes["library.version"])
+							assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestTranslateNonServiceHttpLogsWithoutDatasetRequest(t *testing.T) {
+	traceID := test.RandomBytes(16)
+	spanID := test.RandomBytes(8)
+	startTimestamp := time.Now()
+
+	testServiceName := "unknown_service"
+
+	req := &collectorlogs.ExportLogsServiceRequest{
+		ResourceLogs: []*logs.ResourceLogs{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "resource_attr",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "resource_attr_val"},
+					},
+				}, {
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: testServiceName},
+					},
+				}},
+			},
+			ScopeLogs: []*logs.ScopeLogs{{
+				Scope: &common.InstrumentationScope{
+					Name:    "instr_scope_name",
+					Version: "instr_scope_version",
+					Attributes: []*common.KeyValue{
+						{
+							Key: "scope_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "scope_attr_val"},
+							},
+						},
+					},
+				},
+				LogRecords: []*logs.LogRecord{{
+					TraceId:        traceID,
+					SpanId:         spanID,
+					TimeUnixNano:   uint64(startTimestamp.Nanosecond()),
+					SeverityText:   "test_severity_text",
+					SeverityNumber: logs.SeverityNumber_SEVERITY_NUMBER_DEBUG,
+					Attributes: []*common.KeyValue{
+						{
+							Key: "span_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
+							},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+
+	testCases := []struct {
+		Name            string
+		ri              RequestInfo
+		expectedDataset string
+	}{
+		{
+			Name: "Classic",
+			ri: RequestInfo{
+				ApiKey:  "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+				Dataset: "",
+			},
+			expectedDataset: "unknown_logs_source",
+		},
+		{
+			Name: "E&S",
+			ri: RequestInfo{
+				ApiKey:  "abc123DEF456ghi789jklm",
+				Dataset: "",
+			},
+			expectedDataset: "unknown_logs_source",
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.Name, func(t *testing.T) {
+			for _, testCaseContentType := range GetSupportedContentTypes() {
+				t.Run(testCaseNameForContentType(testCaseContentType), func(t *testing.T) {
+					for _, testCaseContentEncoding := range GetSupportedContentEncodings() {
+						t.Run(testCaseNameForEncoding(testCaseContentEncoding), func(t *testing.T) {
+
+							tC.ri.ContentType = testCaseContentType
+							tC.ri.ContentEncoding = testCaseContentEncoding
+
+							body, err := prepareOtlpRequestHttpBody(req, testCaseContentType, testCaseContentEncoding)
+							require.NoError(t, err, "Womp womp. Ought to have been able to turn the OTLP log request into an HTTP body.")
+
+							result, err := TranslateLogsRequestFromReader(io.NopCloser(strings.NewReader(body)), tC.ri)
+							require.NoError(t, err)
+							assert.Equal(t, proto.Size(req), result.RequestSize)
+							assert.Equal(t, 1, len(result.Batches))
+							batch := result.Batches[0]
+							assert.Equal(t, tC.expectedDataset, batch.Dataset)
+							assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
+							events := batch.Events
+							assert.Equal(t, 1, len(events))
+
+							ev := events[0]
+							assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
+							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+							assert.Equal(t, "log", ev.Attributes["meta.signal_type"])
+							assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
+							assert.Equal(t, uint32(0), ev.Attributes["flags"])
+							assert.Equal(t, "test_severity_text", ev.Attributes["severity_text"])
+							assert.Equal(t, "debug", ev.Attributes["severity"])
+							assert.Equal(t, "unknown_service", ev.Attributes["service.name"])
+							assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
+							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+							assert.Equal(t, "instr_scope_name", ev.Attributes["library.name"])
+							assert.Equal(t, "instr_scope_version", ev.Attributes["library.version"])
+							assert.Equal(t, "scope_attr_val", ev.Attributes["scope_attr"])
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestCanDetectLogSeverity(t *testing.T) {
 	testCases := []struct {
 		name       string


### PR DESCRIPTION
fixes https://github.com/honeycombio/husky/issues/118

I was thinking about refactoring the tests so there wasn't so much duplication, but ... eh. 

So the ultimately fallback - `unknown_log_source` - won't actually get hit in practice because we ultimately require an `x-honeycomb-dataset` header. So I'm validating that in the test instead.