### PR TITLE
[fix] only classic teams must provide a dataset header when sending metrics

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -125,7 +125,7 @@ func (ri *RequestInfo) ValidateMetricsHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
-	if len(ri.Dataset) == 0 {
+	if ri.hasLegacyKey() && len(ri.Dataset) == 0 {
 		return ErrMissingDatasetHeader
 	}
 	if !IsContentTypeSupported(ri.ContentType) {

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -170,9 +170,11 @@ func TestValidateMetricsHeaders(t *testing.T) {
 	}{
 		{name: "no key, no dataset", apikey: "", dataset: "", contentType: "", err: ErrMissingAPIKeyHeader},
 		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "", err: ErrMissingAPIKeyHeader},
+		// classic environments need to tell us which dataset to put metrics in
 		{name: "classic/no dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "", err: ErrMissingDatasetHeader},
 		{name: "classic/dataset present", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
+		// dataset header not required for E&S, there's a fallback
+		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
 		{name: "E&S/dataset present", apikey: "abc123DEF456ghi789jklm", dataset: "dataset", contentType: "application/protobuf", err: nil},
 		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
 		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},


### PR DESCRIPTION
More fallout from the header validation [consolidation](https://github.com/honeycombio/husky/pull/121/commits/3cba35dc0d16d840ee26c00ed9a3e5782b78cc29)-and-[diaspora](https://github.com/honeycombio/husky/pull/122).

E&S environments are not *required* to set x-honeycomb-dataset header; we have a fallback for them. Classic teams must provide a target dataset.