### PR TITLE
fix: avoid nil pointer

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -297,17 +297,17 @@ func parseOtlpRequestBody(body io.ReadCloser, contentType string, contentEncodin
 	switch contentEncoding {
 	case "gzip":
 		gzipReader, err := gzip.NewReader(bodyReader)
-		defer gzipReader.Close()
 		if err != nil {
 			return err
 		}
+		defer gzipReader.Close()
 		reader = gzipReader
 	case "zstd":
 		zstdReader, err := zstd.NewReader(bodyReader)
-		defer zstdReader.Close()
 		if err != nil {
 			return err
 		}
+		defer zstdReader.Close()
 		reader = zstdReader
 	default:
 		reader = bodyReader

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -926,3 +926,23 @@ func TestEvaluateSpanStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestBadTraceRequest(t *testing.T) {
+	for _, contentType := range []string{"application/protobuf", "application/json"} {
+		for _, encoding := range []string{"", "gzip", "zstd"} {
+			t.Run(encoding, func(t *testing.T) {
+				body := io.NopCloser(strings.NewReader("lol"))
+				ri := RequestInfo{
+					ApiKey:          "abc123DEF456ghi789jklm",
+					Dataset:         "legacy-dataset",
+					ContentType:     contentType,
+					ContentEncoding: encoding,
+				}
+
+				_, err := TranslateTraceRequestFromReader(body, ri)
+				assert.NotNil(t, err)
+				assert.Equal(t, ErrFailedParseBody, err)
+			})
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- discovered when looking at unwrapped error handling in the API
- gzip.NewReader and zstd.NewReader return (nil, err) when there is an error
- we can only defer closing them if we got back a reader, otherwise we get a nil pointer

## Short description of the changes

- only call close() on readers we know exist

