### PR TITLE
Add span sample rate to links and events

### DIFF
--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -86,13 +86,16 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					addAttributesToMap(eventAttrs, span.Attributes)
 				}
 
+				// get sample rate after resource and scope attributes have been added
+				sampleRate := getSampleRate(eventAttrs)
+
 				// Now we need to wrap the eventAttrs in an event so we can specify the timestamp
 				// which is the StartTime as a time.Time object
 				timestamp := time.Unix(0, int64(span.StartTimeUnixNano)).UTC()
 				events = append(events, Event{
 					Attributes: eventAttrs,
 					Timestamp:  timestamp,
-					SampleRate: getSampleRate(eventAttrs),
+					SampleRate: sampleRate,
 				})
 
 				for _, sevent := range span.Events {
@@ -119,6 +122,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					events = append(events, Event{
 						Attributes: attrs,
 						Timestamp:  timestamp,
+						SampleRate: sampleRate,
 					})
 				}
 
@@ -146,6 +150,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					events = append(events, Event{
 						Attributes: attrs,
 						Timestamp:  timestamp, // use timestamp from parent span
+						SampleRate: sampleRate,
 					})
 				}
 			}

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -161,7 +161,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 			// event
 			ev = events[1]
 			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-			assert.Equal(t, int32(0), ev.SampleRate)
+			assert.Equal(t, int32(100), ev.SampleRate)
 			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
 			assert.Equal(t, "span_event", ev.Attributes["name"])
 			assert.Equal(t, "test_span", ev.Attributes["parent_name"])
@@ -172,7 +172,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 			// link
 			ev = events[2]
 			assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
-			assert.Equal(t, int32(0), ev.SampleRate)
+			assert.Equal(t, int32(100), ev.SampleRate)
 			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
 			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
 			assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The sample rate for a trace should be added to all events. Currently we only add it to the span and not it's span links and events.

This PR adds the span's sample rate to it's span links and events during processing.

- Fixes #132 

## Short description of the changes
- Get the sample rate for the span and add to span link and span event structs
- Update existing test to verify the sample rate it set correctly

