### PR TITLE
fix: update java library name prefix

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -54,7 +54,7 @@ var (
 
 	// List of per-lang instrumentation library prefixes
 	instrumentationLibraryPrefixes = []string{
-		"io.opentelemetry.instrumentation",            // Java,
+		"io.opentelemetry",                            // Java,
 		"opentelemetry.instrumentation",               // Python & .NET:
 		"opentelemetry-instrumentation",               // Ruby
 		"go.opentelemetry.io/contrib/instrumentation", // Go

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1027,7 +1027,7 @@ func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {
 		},
 		{
 			name: "java",
-			libraryName: "io.opentelemetry.instrumentation.http",
+			libraryName: "io.opentelemetry.tomcat-7.0",
 			isInstrumentationLibrary: true,
 		},
 		{


### PR DESCRIPTION
## Which problem is this PR solving?

- Missed detection of Java instrumentation

## Short description of the changes

- Updates instrumentation prefix for Java instrumentation library names to be `io.opentelemetry` instead of `io.opentelemetry.instrumentation`
- Updates test for known value of an instrumentation library

Instrumentation for Java does not include `instrumentation` as part of its resource span name. Instead, it is `io.opentelemetry.<library>-<version>`. The [instrumenter](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java) also includes the library version as part of the library name.
