### PR TITLE
fix: update dotnet library name prefix

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -55,7 +55,8 @@ var (
 	// List of per-lang instrumentation library prefixes
 	instrumentationLibraryPrefixes = []string{
 		"io.opentelemetry",                            // Java,
-		"opentelemetry.instrumentation",               // Python & .NET:
+		"opentelemetry.instrumentation",               // Python
+		"OpenTelemetry.Instrumentation",               // .NET
 		"opentelemetry-instrumentation",               // Ruby
 		"go.opentelemetry.io/contrib/instrumentation", // Go
 		"@opentelemetry/instrumentation",              // JS

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -54,7 +54,7 @@ var (
 
 	// List of per-lang instrumentation library prefixes
 	instrumentationLibraryPrefixes = []string{
-		"io.opentelemetry.instrumentation",            // Java,
+		"io.opentelemetry",                            // Java,
 		"opentelemetry.instrumentation",               // Python & .NET:
 		"opentelemetry-instrumentation",               // Ruby
 		"go.opentelemetry.io/contrib/instrumentation", // Go

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1031,8 +1031,13 @@ func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {
 			isInstrumentationLibrary: true,
 		},
 		{
-			name: "python / .net",
+			name: "python",
 			libraryName: "opentelemetry.instrumentation.http",
+			isInstrumentationLibrary: true,
+		},
+		{
+			name: ".net",
+			libraryName: "OpenTelemetry.Instrumentation.AspNetCore",
 			isInstrumentationLibrary: true,
 		},
 		{

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1027,7 +1027,7 @@ func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {
 		},
 		{
 			name: "java",
-			libraryName: "io.opentelemetry.instrumentation.http",
+			libraryName: "io.opentelemetry.tomcat-7.0",
 			isInstrumentationLibrary: true,
 		},
 		{


### PR DESCRIPTION
## Which problem is this PR solving?

- Missed detection of .NET instrumentation

## Short description of the changes

- Updates instrumentation prefix for .NET instrumentation library names to be `OpenTelemetry.Instrumentation` instead of `opentelemetry.instrumentation`.
- Updates test for known value of an instrumentation library

While the instrumentation prefix is the same for both python and .net, case sensitivity makes them differ. Another option here could be to lowercase them, but this matches the string the way it's written today.

