### PR TITLE
fix: ingest base64-encoded spanIDs from browsers

### DIFF
--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -240,7 +240,7 @@ func bytesToSpanID(spanID []byte) string {
 		// The spec says that traceID and spanID should be encoded as hex, but
 		// the protobuf system is interpreting them as b64, so we need to
 		// reverse them back to b64 and then reencode as hex.
-		encoded := make([]byte, base64.StdEncoding.EncodedLen(len(spanID)))
+		encoded = make([]byte, base64.StdEncoding.EncodedLen(len(spanID)))
 		base64.StdEncoding.Encode(encoded, spanID)
 	default:
 		encoded = make([]byte, len(spanID)*2)

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1124,3 +1124,43 @@ func Test_BytesToTraceID(t *testing.T) {
 		})
 	}
 }
+
+func Test_BytesToSpanID(t *testing.T) {
+	tests := []struct {
+		name   string
+		spanID string
+		b64    bool
+		want   string
+	}{
+		{
+			name:   "spanID",
+			spanID: "890452a577ef2e0f",
+			want:   "890452a577ef2e0f",
+		},
+		{
+			name:   "spanID munged by browser",
+			spanID: "890452a577ef2e0f",
+			b64:    true,
+			want:   "890452a577ef2e0f",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var spanID []byte
+			var err error
+			if tt.b64 {
+				spanID, err = base64.StdEncoding.DecodeString(tt.spanID)
+			} else {
+				spanID, err = hex.DecodeString(tt.spanID)
+			}
+			if err != nil {
+				spanID = []byte(tt.spanID)
+			}
+			got := bytesToSpanID(spanID)
+			if got != tt.want {
+				t.Errorf("got:  %#v\n\twant: %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Ingesting base64-encoded spanIDs emitted from browsers
- follow-up to #182 

## Short description of the changes

- Added a test to demonstrate the issue
- `:=` -> `=` to fix unintended variable scoping

