### PR TITLE
fix: ingest munged parent span IDs

### DIFF
--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -69,7 +69,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					"meta.signal_type": "trace",
 				}
 				if span.ParentSpanId != nil {
-					eventAttrs["trace.parent_id"] = hex.EncodeToString(span.ParentSpanId)
+					eventAttrs["trace.parent_id"] = bytesToSpanID(span.ParentSpanId)
 				}
 				if isError {
 					eventAttrs["error"] = true


### PR DESCRIPTION
## Which problem is this PR solving?

- follow-up to #184 

## Short description of the changes

- Parse parent span IDs like we do span IDs to deal with base64 shenanigans

