### PR TITLE
feat: copy exception details from span event to parent span

### DIFF
--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -129,9 +129,9 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 							if seventAttr.Key == "exception.message" ||
 								seventAttr.Key == "exception.type" ||
 								seventAttr.Key == "exception.stacktrace" ||
-								seventAttr.Key == "exception.excaped" {
-								if _, present := attrs[seventAttr.Key]; !present {
-									attrs[seventAttr.Key] = seventAttr.Value
+								seventAttr.Key == "exception.escaped" {
+								if _, present := eventAttrs[seventAttr.Key]; !present {
+									eventAttrs[seventAttr.Key] = seventAttr.Value
 								}
 							}
 						}

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -143,8 +143,32 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 			events := batch.Events
 			assert.Equal(t, 3, len(events))
 
-			// span
+			// event
 			ev := events[0]
+			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+			assert.Equal(t, int32(100), ev.SampleRate)
+			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+			assert.Equal(t, "span_event", ev.Attributes["name"])
+			assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+			assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
+			assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
+			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+
+			// link
+			ev = events[1]
+			assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
+			assert.Equal(t, int32(100), ev.SampleRate)
+			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+			assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])
+			assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.Attributes["trace.link.span_id"])
+			assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+			assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
+			assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
+			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+
+			// span
+			ev = events[2]
 			assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
 			assert.Equal(t, int32(100), ev.SampleRate)
 			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
@@ -158,30 +182,6 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 			assert.Equal(t, 1, ev.Attributes["span.num_links"])
 			assert.Equal(t, 1, ev.Attributes["span.num_events"])
-
-			// event
-			ev = events[1]
-			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-			assert.Equal(t, int32(100), ev.SampleRate)
-			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
-			assert.Equal(t, "span_event", ev.Attributes["name"])
-			assert.Equal(t, "test_span", ev.Attributes["parent_name"])
-			assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
-			assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
-			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-
-			// link
-			ev = events[2]
-			assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
-			assert.Equal(t, int32(100), ev.SampleRate)
-			assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-			assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
-			assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])
-			assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.Attributes["trace.link.span_id"])
-			assert.Equal(t, "test_span", ev.Attributes["parent_name"])
-			assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
-			assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
-			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 		})
 	}
 }
@@ -432,8 +432,29 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 							events := batch.Events
 							assert.Equal(t, 3, len(events))
 
-							// span
+							// event
 							ev := events[0]
+							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+							assert.Equal(t, "span_event", ev.Attributes["name"])
+							assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+							assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
+							assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
+							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+
+							// link
+							ev = events[1]
+							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
+							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
+							assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])
+							assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.Attributes["trace.link.span_id"])
+							assert.Equal(t, "test_span", ev.Attributes["parent_name"])
+							assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
+							assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
+							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+
+							// span
+							ev = events[2]
 							assert.Equal(t, startTimestamp.Nanosecond(), ev.Timestamp.Nanosecond())
 							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
 							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.span_id"])
@@ -444,27 +465,6 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 							assert.Equal(t, float64(endTimestamp.Nanosecond()-startTimestamp.Nanosecond())/float64(time.Millisecond), ev.Attributes["duration_ms"])
 							assert.Equal(t, int(trace.Status_STATUS_CODE_OK), ev.Attributes["status_code"])
 							assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
-							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-
-							// event
-							ev = events[1]
-							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
-							assert.Equal(t, "span_event", ev.Attributes["name"])
-							assert.Equal(t, "test_span", ev.Attributes["parent_name"])
-							assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
-							assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
-							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
-
-							// link
-							ev = events[2]
-							assert.Equal(t, BytesToTraceID(traceID), ev.Attributes["trace.trace_id"])
-							assert.Equal(t, hex.EncodeToString(spanID), ev.Attributes["trace.parent_id"])
-							assert.Equal(t, BytesToTraceID(linkedTraceID), ev.Attributes["trace.link.trace_id"])
-							assert.Equal(t, hex.EncodeToString(linkedSpanID), ev.Attributes["trace.link.span_id"])
-							assert.Equal(t, "test_span", ev.Attributes["parent_name"])
-							assert.Equal(t, "link", ev.Attributes["meta.annotation_type"])
-							assert.Equal(t, "span_link_attr_val", ev.Attributes["span_link_attr"])
 							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 						})
 					}


### PR DESCRIPTION
This came from a discussion and screen share with @puckpuck

So, today, as we know, exceptions get captured as span events with OTel. That's fine.

However, it's not so fine for us, namely:

1. Querying them is a little awkward since you're often looking/caring about spans, but you need to actually query the span events. This makes it harder to do bubble ups and see what error/exception info differs.
2. Digging into a trace with an error yields no data on the span; you need to click into the span events tab (which people often miss!) and then find the span event that has the error details (there can be several that have no errors) and _then_ you can see the actual exception detail

This solves both problems by copying the exception details onto the parent span that has those events.