### PR TITLE
maint: Remove refs to proxy token and headers

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -24,8 +24,6 @@ import (
 const (
 	apiKeyHeader             = "x-honeycomb-team"
 	datasetHeader            = "x-honeycomb-dataset"
-	proxyTokenHeader         = "x-honeycomb-proxy-token"
-	proxyVersionHeader       = "x-basenji-version"
 	userAgentHeader          = "user-agent"
 	contentTypeHeader        = "content-type"
 	contentEncodingHeader    = "content-encoding"
@@ -108,10 +106,8 @@ type Event struct {
 
 // RequestInfo represents information parsed from either HTTP headers or gRPC metadata
 type RequestInfo struct {
-	ApiKey       string
-	Dataset      string
-	ProxyToken   string
-	ProxyVersion string
+	ApiKey  string
+	Dataset string
 
 	UserAgent          string
 	ContentType        string
@@ -170,8 +166,6 @@ func GetRequestInfoFromGrpcMetadata(ctx context.Context) RequestInfo {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		ri.ApiKey = getValueFromMetadata(md, apiKeyHeader)
 		ri.Dataset = getValueFromMetadata(md, datasetHeader)
-		ri.ProxyToken = getValueFromMetadata(md, proxyTokenHeader)
-		ri.ProxyVersion = getValueFromMetadata(md, proxyVersionHeader)
 		ri.UserAgent = getValueFromMetadata(md, userAgentHeader)
 		ri.ContentEncoding = getValueFromMetadata(md, contentEncodingHeader)
 		ri.GRPCAcceptEncoding = getValueFromMetadata(md, gRPCAcceptEncodingHeader)
@@ -184,8 +178,6 @@ func GetRequestInfoFromHttpHeaders(header http.Header) RequestInfo {
 	return RequestInfo{
 		ApiKey:             header.Get(apiKeyHeader),
 		Dataset:            header.Get(datasetHeader),
-		ProxyToken:         header.Get(proxyTokenHeader),
-		ProxyVersion:       header.Get(proxyVersionHeader),
 		UserAgent:          header.Get(userAgentHeader),
 		ContentType:        header.Get(contentTypeHeader),
 		ContentEncoding:    header.Get(contentEncodingHeader),

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -14,18 +14,14 @@ import (
 
 func TestParseGrpcMetadataIntoRequestInfo(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
-		apiKeyHeader:       "test-api-key",
-		datasetHeader:      "test-dataset",
-		proxyTokenHeader:   "test-proxy-token",
-		proxyVersionHeader: "test-proxy-version",
-		userAgentHeader:    "test-user-agent",
+		apiKeyHeader:    "test-api-key",
+		datasetHeader:   "test-dataset",
+		userAgentHeader: "test-user-agent",
 	}))
 	ri := GetRequestInfoFromGrpcMetadata(ctx)
 
 	assert.Equal(t, "test-api-key", ri.ApiKey)
 	assert.Equal(t, "test-dataset", ri.Dataset)
-	assert.Equal(t, "test-proxy-token", ri.ProxyToken)
-	assert.Equal(t, "test-proxy-version", ri.ProxyVersion)
 	assert.Equal(t, "test-user-agent", ri.UserAgent)
 	assert.Equal(t, "application/protobuf", ri.ContentType)
 }
@@ -34,14 +30,12 @@ func TestParseHttpHeadersIntoRequestInfo(t *testing.T) {
 	header := http.Header{}
 	header.Set(apiKeyHeader, "test-api-key")
 	header.Set(datasetHeader, "test-dataset")
-	header.Set(proxyTokenHeader, "test-proxy-token")
 	header.Set(userAgentHeader, "test-user-agent")
 	header.Set(contentTypeHeader, "test-content-type")
 
 	ri := GetRequestInfoFromHttpHeaders(header)
 	assert.Equal(t, "test-api-key", ri.ApiKey)
 	assert.Equal(t, "test-dataset", ri.Dataset)
-	assert.Equal(t, "test-proxy-token", ri.ProxyToken)
 	assert.Equal(t, "test-user-agent", ri.UserAgent)
 	assert.Equal(t, "test-content-type", ri.ContentType)
 }
@@ -269,13 +263,11 @@ func TestGetRequestInfoFromGrpcMetadataIsCaseInsensitive(t *testing.T) {
 			md := metadata.MD{}
 			md.Set(tt.apikeyHeader, apiKeyValue)
 			md.Set(tt.datasetHeader, datasetValue)
-			md.Set(tt.proxyTokenHeader, proxyTokenValue)
 
 			ctx := metadata.NewIncomingContext(context.Background(), md)
 			ri := GetRequestInfoFromGrpcMetadata(ctx)
 			assert.Equal(t, apiKeyValue, ri.ApiKey)
 			assert.Equal(t, datasetValue, ri.Dataset)
-			assert.Equal(t, proxyTokenValue, ri.ProxyToken)
 		})
 	}
 }
@@ -318,12 +310,10 @@ func TestGetRequestInfoFromHttpHeadersIsCaseInsensitive(t *testing.T) {
 			header := http.Header{}
 			header.Set(apiKeyHeader, apiKeyValue)
 			header.Set(datasetHeader, datasetValue)
-			header.Set(proxyTokenHeader, proxyTokenValue)
 
 			ri := GetRequestInfoFromHttpHeaders(header)
 			assert.Equal(t, apiKeyValue, ri.ApiKey)
 			assert.Equal(t, datasetValue, ri.Dataset)
-			assert.Equal(t, proxyTokenValue, ri.ProxyToken)
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Honeycomb has ended the life of its secure tenancy proxy. The headers associated with it are now obsolete.

## Short description of the changes

- Remove refs to and tests for `x-honeycomb-proxy-token` and `x-basenji-version`.

