### PR TITLE
maint: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     labels:
       - "type: dependencies"
     reviewers:
-      - "honeycombio/telemetry-team"
+      - "honeycombio/collection-team"
     commit-message:
       prefix: "maint"
       include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

- dependabot still notifies telemetry when it opens PRs

