### PR TITLE
Copy span attributes onto events by default

### DIFF
--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -115,6 +115,9 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 						attrs[k] = v
 					}
 
+				  if span.Attributes != nil {
+            addAttributesToMap(attrs, span.Attributes)
+          }
 					if sevent.Attributes != nil {
 						addAttributesToMap(attrs, sevent.Attributes)
 					}

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -115,9 +115,9 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 						attrs[k] = v
 					}
 
-				  if span.Attributes != nil {
-            addAttributesToMap(attrs, span.Attributes)
-          }
+					if span.Attributes != nil {
+						addAttributesToMap(attrs, span.Attributes)
+					}
 					if sevent.Attributes != nil {
 						addAttributesToMap(attrs, sevent.Attributes)
 					}

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -152,7 +152,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 			assert.Equal(t, "test_span", ev.Attributes["parent_name"])
 			assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
 			assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
-			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr_val"])
+			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 
 			// link

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -152,6 +152,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 			assert.Equal(t, "test_span", ev.Attributes["parent_name"])
 			assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
 			assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
+			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr_val"])
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 
 			// link


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

It is common for people to add attributes via the baggage span processor. It is expected that we should be able to query based on those attributes.

The current state of affairs treats events as entirely separate from spans, and as such we cannot query things like `COUNT where name = "something-happened" group by app.tenant_id`. 

## Short description of the changes

- Copy all attributes from the span onto the event