### PR TITLE
feat: Add public functions for handling OTLP HTTP responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 unit-tests.xml
+
+.idea


### PR DESCRIPTION
## Which problem is this PR solving?

OTLP HTTP protocol is very specific with how a server should respond to a client. This PR adds new functions to help handle OTLP HTTP response requirements:
1. Must set the content type to match in request content type
2. A status code must be set
3. For Success, a the response body MUST be a `Export[Trace|Metrics|Logs]ServiceResponse` with a nil PartialSuccess.
4. For errors, the response body MUST be a [Status](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/status#Status).

See https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp for full requirements.

## Short description of the changes

- Adds several new functions to help users respond to HTTP OTLP requests.
- Adds new unit tests for these functions.

