### PR TITLE
maint: add extra detail to release doc

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,12 @@
 # Release Process
 
-1. Update [Version.go](version.go) with new version
-2. Add release entry to [changelog](./CHANGELOG.md). Consider using a command like so:
-    * `git log --pretty='%C(green)%d%Creset- %s | [%an](https://github.com/)'`
-3. Open a PR with the above, and merge that into main
-4. Create new tag on merged commit with the new version (e.g. `v1.4.1`)
-5. Push the tag upstream (this will kick off the release pipeline in CI)
-6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
+- Update [`version.go`](version.go) with new version
+- Add release entry to [changelog](./CHANGELOG.md). Consider using a command like so:
+  - `git log --pretty='%C(green)%d%Creset- %s | [%an](https://github.com/)'`
+- Commit changes, push, and open a release preparation pull request for review.
+- Once the pull request is merged, fetch the updated `main` branch.
+- Apply a tag for the new version on the merged commit (e.g. `git tag -a v2.3.1 -m "v2.3.1"`)
+- Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v2.3.1`
+- Ensure that there is a draft GitHub release created as part of CI publish steps
+- Click "generate release notes" in github for full changelog notes and any new contributors
+- Publish the github draft release


### PR DESCRIPTION
## Which problem is this PR solving?

- maintaining consistency on releasing and being as explicit as possible

## Short description of the changes

- add a bit more detail to releasing doc, especially for specifying annotated tags and generating release notes

