### PR TITLE
feat: change status_code to span.status_code

### DIFF
--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -63,7 +63,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					"span.kind":        spanKind,
 					"name":             span.Name,
 					"duration_ms":      float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond),
-					"status_code":      statusCode,
+					"span.status_code": statusCode,
 					"span.num_links":   len(span.Links),
 					"span.num_events":  len(span.Events),
 					"meta.signal_type": "trace",


### PR DESCRIPTION
This has been something that's bothered me for quite a bit, and I think we talked about it in a sync at least a year ago.

The issue with our current behavior is that in the _vast_ majority of use cases, when someone says "status code" they actually mean "http status code" and not "span status code". However, I've seen people type out `status_code` before. I've also seen Query Assistant make this mistake (although it tends to not do this terribly often).

Moreover, I believe that there aren't a whole lot of useful queries people run that rely on the span status code itself unless they're debugging their own instrumentation. In that case, I think it's _more_ clarifying to have the field be named `span.status_code`.

A cursory glance at pollinators yields some interesting things:

- https://honeycombpollinators.slack.com/archives/C01BZ3J7RMJ/p1700477529510069 someone using `status_code` in Refinery rules to refer to an HTTP status code, and I've confirmed they also use OTel. I'd be curious if that rule has ever worked...
- https://honeycombpollinators.slack.com/archives/C01BZ3J7RMJ/p1689092857772999?thread_ts=1689092818.163909&cid=C01BZ3J7RMJ -- someone actually using this field correctly in a refinery config
- https://honeycombpollinators.slack.com/archives/C017T9FFT0D/p1687900384463209?thread_ts=1687889683.779059&cid=C017T9FFT0D -- example of an SLO definition that will fail if the service switches over to OTel (since `status_code` today will just be 0/1/2)
- https://honeycombpollinators.slack.com/archives/C01BZ3J7RMJ/p1680804713304559?thread_ts=1680804245.737379&cid=C01BZ3J7RMJ -- someone's refinery config that would break
- https://honeycombpollinators.slack.com/archives/C01BZ3J7RMJ/p1675092087461469?thread_ts=1675080682.038819&cid=C01BZ3J7RMJ -- example of a potential refinery config that wouldn't work with OTel
- https://honeycombpollinators.slack.com/archives/C4T3A32CX/p1673866269285839?thread_ts=1673863400.460099&cid=C4T3A32CX -- example DC that wouldn't work with OTel

Mainly, it seems that when people say "status code" they are almost always referring to "HTTP status code" in Pollinators. I'm also very curious how many people are sending OTLP and using `status_code` to refer to "HTTP status code" in DCs, queries, SLOs, Triggers, etc. and said nouns are simply not working as expected because the underlying values are just 0/1/2. I can't think of a way to measure that, though.

What are peoples' thoughts on rolling out this change? We'd need to broadcast to people that we're making this change, and at least mention to that one user specifically that we're changing the field to `span.status_code`.