### PR TITLE
fix: properly parse parent id for logs

### DIFF
--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -2,6 +2,8 @@ package otlp
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -496,6 +498,66 @@ func Test_WriteOtlpHttpFailureResponse(t *testing.T) {
 	}
 }
 
+func Test_BytesToTraceID(t *testing.T) {
+	tests := []struct {
+		name    string
+		traceID string
+		b64     bool
+		want    string
+	}{
+		{
+			name:    "64-bit traceID",
+			traceID: "cbe4decd12429177",
+			want:    "cbe4decd12429177",
+		},
+		{
+			name:    "128-bit zero-padded traceID",
+			traceID: "0000000000000000cbe4decd12429177",
+			want:    "cbe4decd12429177",
+		},
+		{
+			name:    "128-bit non-zero-padded traceID",
+			traceID: "f23b42eac289a0fdcde48fcbe3ab1a32",
+			want:    "f23b42eac289a0fdcde48fcbe3ab1a32",
+		},
+		{
+			name:    "Non-hex traceID",
+			traceID: "foobar1",
+			want:    "666f6f62617231",
+		},
+		{
+			name:    "Longer non-hex traceID",
+			traceID: "foobarbaz",
+			want:    "666f6f62617262617a",
+		},
+		{
+			name:    "traceID munged by browser",
+			traceID: "6e994e8673e93a51200c137330aeddad",
+			b64:     true,
+			want:    "6e994e8673e93a51200c137330aeddad",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var traceID []byte
+			var err error
+			if tt.b64 {
+				traceID, err = base64.StdEncoding.DecodeString(tt.traceID)
+			} else {
+				traceID, err = hex.DecodeString(tt.traceID)
+			}
+			if err != nil {
+				traceID = []byte(tt.traceID)
+			}
+			got := BytesToTraceID(traceID)
+			if got != tt.want {
+				t.Errorf("got:  %#v\n\twant: %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_WriteOtlpHttpTraceSuccessResponse(t *testing.T) {
 	tests := []struct {
 		contentType   string
@@ -641,6 +703,52 @@ func Test_WriteOtlpHttpLogSuccessResponse(t *testing.T) {
 					assert.NoError(t, err)
 				}
 				assert.Nil(t, result.GetPartialSuccess())
+			}
+		})
+	}
+}
+
+func Test_BytesToSpanID(t *testing.T) {
+	tests := []struct {
+		name   string
+		spanID string
+		b64    bool
+		want   string
+	}{
+		{
+			name:   "spanID",
+			spanID: "890452a577ef2e0f",
+			want:   "890452a577ef2e0f",
+		},
+		{
+			name:   "spanID munged by browser (converted in this test)",
+			spanID: "890452a577ef2e0f",
+			b64:    true,
+			want:   "890452a577ef2e0f",
+		},
+		{
+			name:   "spanID munged by browser (from a bad trace)",
+			spanID: "e77ddbeb7f7adf77fbd396b9",
+			b64:    false,
+			want:   "533b639633f705a5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var spanID []byte
+			var err error
+			if tt.b64 {
+				spanID, err = base64.StdEncoding.DecodeString(tt.spanID)
+			} else {
+				spanID, err = hex.DecodeString(tt.spanID)
+			}
+			if err != nil {
+				spanID = []byte(tt.spanID)
+			}
+			got := BytesToSpanID(spanID)
+			if got != tt.want {
+				t.Errorf("got:  %#v\n\twant: %#v", got, tt.want)
 			}
 		})
 	}

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -1,7 +1,6 @@
 package otlp
 
 import (
-	"encoding/hex"
 	"io"
 	"time"
 
@@ -51,7 +50,7 @@ func TranslateLogsRequest(request *collectorLogs.ExportLogsServiceRequest, ri Re
 					attrs["meta.annotation_type"] = "span_event"
 				}
 				if len(log.SpanId) > 0 {
-					attrs["trace.parent_id"] = hex.EncodeToString(log.SpanId)
+					attrs["trace.parent_id"] = bytesToSpanID(log.SpanId)
 				}
 				if log.SeverityText != "" {
 					attrs["severity_text"] = log.SeverityText

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -50,7 +50,7 @@ func TranslateLogsRequest(request *collectorLogs.ExportLogsServiceRequest, ri Re
 					attrs["meta.annotation_type"] = "span_event"
 				}
 				if len(log.SpanId) > 0 {
-					attrs["trace.parent_id"] = bytesToSpanID(log.SpanId)
+					attrs["trace.parent_id"] = BytesToSpanID(log.SpanId)
 				}
 				if log.SeverityText != "" {
 					attrs["severity_text"] = log.SeverityText

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -247,7 +247,7 @@ func BytesToTraceID(traceID []byte) string {
 	case traceIDb64Length: // 24 bytes
 		// The spec says that traceID and spanID should be encoded as hex, but
 		// the protobuf system is interpreting them as b64, so we need to
-		// reverse them back to b64 and then reencode as hex.
+		// reverse them back to b64 which gives us the original hex.
 		encoded = make([]byte, base64.StdEncoding.EncodedLen(len(traceID)))
 		base64.StdEncoding.Encode(encoded, traceID)
 	default:
@@ -263,7 +263,7 @@ func bytesToSpanID(spanID []byte) string {
 	case spanIDb64Length: // 12 bytes
 		// The spec says that traceID and spanID should be encoded as hex, but
 		// the protobuf system is interpreting them as b64, so we need to
-		// reverse them back to b64 and then reencode as hex.
+		// reverse them back to b64 which gives us the original hex.
 		encoded = make([]byte, base64.StdEncoding.EncodedLen(len(spanID)))
 		base64.StdEncoding.Encode(encoded, spanID)
 	default:

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -1,7 +1,6 @@
 package otlp
 
 import (
-	"encoding/base64"
 	"encoding/hex"
 	"io"
 	"math"
@@ -51,7 +50,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 
 			for _, span := range scopeSpan.GetSpans() {
 				traceID := BytesToTraceID(span.TraceId)
-				spanID := bytesToSpanID(span.SpanId)
+				spanID := BytesToSpanID(span.SpanId)
 
 				spanKind := getSpanKind(span.Kind)
 				statusCode, isError := getSpanStatusCode(span.Status)
@@ -69,7 +68,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					"meta.signal_type": "trace",
 				}
 				if span.ParentSpanId != nil {
-					eventAttrs["trace.parent_id"] = bytesToSpanID(span.ParentSpanId)
+					eventAttrs["trace.parent_id"] = BytesToSpanID(span.ParentSpanId)
 				}
 				if isError {
 					eventAttrs["error"] = true
@@ -221,65 +220,6 @@ func getSpanKind(kind trace.Span_SpanKind) string {
 	default:
 		return "unspecified"
 	}
-}
-
-// BytesToTraceID returns an ID suitable for use for spans and traces. Before
-// encoding the bytes as a hex string, we want to handle cases where we are
-// given 128-bit IDs with zero padding, e.g. 0000000000000000f798a1e7f33c8af6.
-// There are many ways to achieve this, but careful benchmarking and testing
-// showed the below as the most performant, avoiding memory allocations
-// and the use of flexible but expensive library functions. As this is hot code,
-// it seemed worthwhile to do it this way.
-func BytesToTraceID(traceID []byte) string {
-	var encoded []byte
-	switch len(traceID) {
-	case traceIDLongLength: // 16 bytes, trim leading 8 bytes if all 0's
-		if shouldTrimTraceId(traceID) {
-			encoded = make([]byte, 16)
-			traceID = traceID[traceIDShortLength:]
-		} else {
-			encoded = make([]byte, 32)
-		}
-		hex.Encode(encoded, traceID)
-	case traceIDShortLength: // 8 bytes
-		encoded = make([]byte, 16)
-		hex.Encode(encoded, traceID)
-	case traceIDb64Length: // 24 bytes
-		// The spec says that traceID and spanID should be encoded as hex, but
-		// the protobuf system is interpreting them as b64, so we need to
-		// reverse them back to b64 which gives us the original hex.
-		encoded = make([]byte, base64.StdEncoding.EncodedLen(len(traceID)))
-		base64.StdEncoding.Encode(encoded, traceID)
-	default:
-		encoded = make([]byte, len(traceID)*2)
-		hex.Encode(encoded, traceID)
-	}
-	return string(encoded)
-}
-
-func bytesToSpanID(spanID []byte) string {
-	var encoded []byte
-	switch len(spanID) {
-	case spanIDb64Length: // 12 bytes
-		// The spec says that traceID and spanID should be encoded as hex, but
-		// the protobuf system is interpreting them as b64, so we need to
-		// reverse them back to b64 which gives us the original hex.
-		encoded = make([]byte, base64.StdEncoding.EncodedLen(len(spanID)))
-		base64.StdEncoding.Encode(encoded, spanID)
-	default:
-		encoded = make([]byte, len(spanID)*2)
-		hex.Encode(encoded, spanID)
-	}
-	return string(encoded)
-}
-
-func shouldTrimTraceId(traceID []byte) bool {
-	for i := 0; i < 8; i++ {
-		if traceID[i] != 0 {
-			return false
-		}
-	}
-	return true
 }
 
 // getSpanStatusCode returns the integer value of the span's status code and

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1303,10 +1303,16 @@ func Test_BytesToSpanID(t *testing.T) {
 			want:   "890452a577ef2e0f",
 		},
 		{
-			name:   "spanID munged by browser",
+			name:   "spanID munged by browser (converted in this test)",
 			spanID: "890452a577ef2e0f",
 			b64:    true,
 			want:   "890452a577ef2e0f",
+		},
+		{
+			name:   "spanID munged by browser (from a bad trace)",
+			spanID: "e77ddbeb7f7adf77fbd396b9",
+			b64:    false,
+			want:   "533b639633f705a5",
 		},
 	}
 

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -2,7 +2,6 @@ package otlp
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/hex"
 	"io"
 	"math"
@@ -1226,112 +1225,6 @@ func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.isInstrumentationLibrary, isInstrumentationLibrary(test.libraryName))
-		})
-	}
-}
-
-func Test_BytesToTraceID(t *testing.T) {
-	tests := []struct {
-		name    string
-		traceID string
-		b64     bool
-		want    string
-	}{
-		{
-			name:    "64-bit traceID",
-			traceID: "cbe4decd12429177",
-			want:    "cbe4decd12429177",
-		},
-		{
-			name:    "128-bit zero-padded traceID",
-			traceID: "0000000000000000cbe4decd12429177",
-			want:    "cbe4decd12429177",
-		},
-		{
-			name:    "128-bit non-zero-padded traceID",
-			traceID: "f23b42eac289a0fdcde48fcbe3ab1a32",
-			want:    "f23b42eac289a0fdcde48fcbe3ab1a32",
-		},
-		{
-			name:    "Non-hex traceID",
-			traceID: "foobar1",
-			want:    "666f6f62617231",
-		},
-		{
-			name:    "Longer non-hex traceID",
-			traceID: "foobarbaz",
-			want:    "666f6f62617262617a",
-		},
-		{
-			name:    "traceID munged by browser",
-			traceID: "6e994e8673e93a51200c137330aeddad",
-			b64:     true,
-			want:    "6e994e8673e93a51200c137330aeddad",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var traceID []byte
-			var err error
-			if tt.b64 {
-				traceID, err = base64.StdEncoding.DecodeString(tt.traceID)
-			} else {
-				traceID, err = hex.DecodeString(tt.traceID)
-			}
-			if err != nil {
-				traceID = []byte(tt.traceID)
-			}
-			got := BytesToTraceID(traceID)
-			if got != tt.want {
-				t.Errorf("got:  %#v\n\twant: %#v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_BytesToSpanID(t *testing.T) {
-	tests := []struct {
-		name   string
-		spanID string
-		b64    bool
-		want   string
-	}{
-		{
-			name:   "spanID",
-			spanID: "890452a577ef2e0f",
-			want:   "890452a577ef2e0f",
-		},
-		{
-			name:   "spanID munged by browser (converted in this test)",
-			spanID: "890452a577ef2e0f",
-			b64:    true,
-			want:   "890452a577ef2e0f",
-		},
-		{
-			name:   "spanID munged by browser (from a bad trace)",
-			spanID: "e77ddbeb7f7adf77fbd396b9",
-			b64:    false,
-			want:   "533b639633f705a5",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var spanID []byte
-			var err error
-			if tt.b64 {
-				spanID, err = base64.StdEncoding.DecodeString(tt.spanID)
-			} else {
-				spanID, err = hex.DecodeString(tt.spanID)
-			}
-			if err != nil {
-				spanID = []byte(tt.spanID)
-			}
-			got := bytesToSpanID(spanID)
-			if got != tt.want {
-				t.Errorf("got:  %#v\n\twant: %#v", got, tt.want)
-			}
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- In https://github.com/honeycombio/husky/pull/179 we added some code to deal with the fact that OTLP/JSON  processing can't differentiate between arrays of bytes that are encoded as hex and those that are encoded as base64. When JS sends us browser-side telemetry, it encodes IDs as hex, but when we receive it it's decoded as base64. This PR also applies that to logs.

## Short description of the changes

- Adjust log's parentID so that it properly parses
- Add a new test case
- Move some code to common since it now applies across signals
- Move some tests to common
- Clarify some comments

