### PR TITLE
fix: Handle case of endtime before starttime

### DIFF
--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -69,7 +69,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 				duration := float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond)
 				if duration < 0 {
 					duration = 0
-					eventAttrs["meta.negative_duration"] = true
+					eventAttrs["meta.invalid_duration"] = true
 				}
 				eventAttrs["duration_ms"] = duration
 

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -61,12 +61,18 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					"type":             spanKind,
 					"span.kind":        spanKind,
 					"name":             span.Name,
-					"duration_ms":      float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond),
 					"status_code":      statusCode,
 					"span.num_links":   len(span.Links),
 					"span.num_events":  len(span.Events),
 					"meta.signal_type": "trace",
 				}
+				duration := float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond)
+				if duration < 0 {
+					duration = 0
+					eventAttrs["meta.negative_duration"] = true
+				}
+				eventAttrs["duration_ms"] = duration
+
 				if span.ParentSpanId != nil {
 					eventAttrs["trace.parent_id"] = BytesToSpanID(span.ParentSpanId)
 				}


### PR DESCRIPTION
## Which problem is this PR solving?

- #211

## Short description of the changes

- Check for negative value and use 0 instead
- Add `meta.negative_duration = true` if that happens


Closes #211 

