### PR TITLE
docs: fix typo in section heading

### DIFF
--- a/otlp/README.md
+++ b/otlp/README.md
@@ -3,7 +3,7 @@
 This module provides an easy to use way of converting OTLP requests into easily ingestible data structures (eg `[]map[string]interface{}`).
 This makes consuming the OTLP wire format easier and more consistent.
 
-### Traces
+### Traces
 
 You can either provide the OTLP trace request directly or a HTTP request object that contains the request in the body.
 


### PR DESCRIPTION
Skip changelog, etc -- fixes a cosmetic defect in the docs.