### PR TITLE
feat: Allow flattening of OTLP key-value lists

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -39,7 +39,7 @@ const (
 	unknownLogSource         = "unknown_log_source"
 
 	// maxDepth is the maximum depth of a nested kvlist attribute that will be flattened.
-	// If the depth is exceeded, the attribute should be added as a JSON string.
+	// If the depth is exceeded, the attribute should be added as a JSON string instead.
 	maxDepth = 5
 )
 
@@ -261,7 +261,7 @@ func getValueFromMetadata(md metadata.MD, key string) string {
 // AddAttributesToMap adds attributes to a map, extracting the underlying attribute data type.
 // Supported types are string, bool, double, int, bytes, array, and kvlist.
 // kvlist attributes are flattened to a depth of (maxDepth), if the depth is exceeded, the attribute is added as a JSON string.
-// Bytes and array values are added as JSON strings.
+// Bytes and array values are always added as JSON strings.
 func AddAttributesToMap(attrs map[string]interface{}, attributes []*common.KeyValue) {
 	for _, attr := range attributes {
 		// ignore entries if the key is empty or value is nil
@@ -403,7 +403,7 @@ func getMarshallableValue(value *common.AnyValue) interface{} {
 // addAttributeToMap adds an attribute to a map, extracting the underlying attribute data type.
 // Supported types are string, bool, double, int, bytes, array, and kvlist.
 // kvlist attributes are flattened to a depth of (maxDepth), if the depth is exceeded, the attribute is added as a JSON string.
-// Bytes and array values are added as JSON strings.
+// Bytes and array values are always added as JSON strings.
 func addAttributeToMap(result map[string]interface{}, key string, value *common.AnyValue, depth int) {
 	switch value.Value.(type) {
 	case *common.AnyValue_StringValue:

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -324,24 +324,48 @@ func TestCanExtractBody(t *testing.T) {
 		expectedValue interface{}
 	}{
 		{
-			name:          "string",
-			body:          &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "string_body"}},
-			expectedValue: "string_body",
+			name: "string",
+			body: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "string_body"}},
+			expectedValue: map[string]interface{}{
+				"body":             "string_body",
+				"flags":            uint32(0),
+				"meta.signal_type": "log",
+				"severity":         "unspecified",
+				"severity_code":    0,
+			},
 		},
 		{
-			name:          "int",
-			body:          &common.AnyValue{Value: &common.AnyValue_IntValue{IntValue: 100}},
-			expectedValue: int64(100),
+			name: "int",
+			body: &common.AnyValue{Value: &common.AnyValue_IntValue{IntValue: 100}},
+			expectedValue: map[string]interface{}{
+				"body":             int64(100),
+				"flags":            uint32(0),
+				"meta.signal_type": "log",
+				"severity":         "unspecified",
+				"severity_code":    0,
+			},
 		},
 		{
-			name:          "bool",
-			body:          &common.AnyValue{Value: &common.AnyValue_BoolValue{BoolValue: true}},
-			expectedValue: true,
+			name: "bool",
+			body: &common.AnyValue{Value: &common.AnyValue_BoolValue{BoolValue: true}},
+			expectedValue: map[string]interface{}{
+				"body":             true,
+				"flags":            uint32(0),
+				"meta.signal_type": "log",
+				"severity":         "unspecified",
+				"severity_code":    0,
+			},
 		},
 		{
-			name:          "double",
-			body:          &common.AnyValue{Value: &common.AnyValue_DoubleValue{DoubleValue: 12.34}},
-			expectedValue: 12.34,
+			name: "double",
+			body: &common.AnyValue{Value: &common.AnyValue_DoubleValue{DoubleValue: 12.34}},
+			expectedValue: map[string]interface{}{
+				"body":             12.34,
+				"flags":            uint32(0),
+				"meta.signal_type": "log",
+				"severity":         "unspecified",
+				"severity_code":    0,
+			},
 		},
 		{
 			name: "array",
@@ -351,7 +375,13 @@ func TestCanExtractBody(t *testing.T) {
 				{Value: &common.AnyValue_BoolValue{BoolValue: true}},
 			},
 			}}},
-			expectedValue: "[\"one\",2,true]\n",
+			expectedValue: map[string]interface{}{
+				"body":             "[\"one\",2,true]\n",
+				"flags":            uint32(0),
+				"meta.signal_type": "log",
+				"severity":         "unspecified",
+				"severity_code":    0,
+			},
 		},
 		{
 			name: "kvlist",
@@ -362,7 +392,16 @@ func TestCanExtractBody(t *testing.T) {
 					{Key: "key3", Value: &common.AnyValue{Value: &common.AnyValue_BoolValue{BoolValue: true}}},
 				},
 			}}},
-			expectedValue: "{\"key1\":\"value1\",\"key2\":2,\"key3\":true}\n",
+			expectedValue: map[string]interface{}{
+				"body":             "{\"key1\":\"value1\",\"key2\":2,\"key3\":true}\n",
+				"body.key1":        "value1",
+				"body.key2":        int64(2),
+				"body.key3":        true,
+				"flags":            uint32(0),
+				"meta.signal_type": "log",
+				"severity":         "unspecified",
+				"severity_code":    0,
+			},
 		},
 	}
 	ri := RequestInfo{
@@ -385,7 +424,7 @@ func TestCanExtractBody(t *testing.T) {
 			result, err := TranslateLogsRequest(req, ri)
 			assert.NotNil(t, result)
 			assert.Nil(t, err)
-			assert.Equal(t, tc.expectedValue, result.Batches[0].Events[0].Attributes["body"])
+			assert.Equal(t, tc.expectedValue, result.Batches[0].Events[0].Attributes)
 		})
 	}
 }

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -91,7 +91,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					eventAttrs[k] = v
 				}
 				if span.Attributes != nil {
-					addAttributesToMap(eventAttrs, span.Attributes)
+					AddAttributesToMap(eventAttrs, span.Attributes)
 				}
 
 				// get sample rate after resource and scope attributes have been added
@@ -121,7 +121,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					}
 
 					if sevent.Attributes != nil {
-						addAttributesToMap(attrs, sevent.Attributes)
+						AddAttributesToMap(attrs, sevent.Attributes)
 					}
 					if isError {
 						attrs["error"] = true
@@ -177,7 +177,7 @@ func TranslateTraceRequest(request *collectorTrace.ExportTraceServiceRequest, ri
 					}
 
 					if slink.Attributes != nil {
-						addAttributesToMap(attrs, slink.Attributes)
+						AddAttributesToMap(attrs, slink.Attributes)
 					}
 					if isError {
 						attrs["error"] = true


### PR DESCRIPTION
## Which problem is this PR solving?
When translating OTLP kv lists we currently just encode as a JSON string which isn't particularly useful. This PR extends the extraction behaviour to traverse kv lists to generate multiple event fields. The max depth is set to 5 levels.

For example, this kv attribute:
```
key: "data"
value: {
  "key1": "val1",
  "key2": true,
}
```

Previously would be stored like this:
```
data: "{\"key1\": \"val1\","key2":true}"
```

After the change, the same kv list would be stored like this:
```
data.key1: "val1"
data.key2: true
```

This change exposes the `AddAttributesToMap` func for consumers to use directly. This will be useful until metrics translation can be moved into this library (eg from shepherd).

- Closes #235 

## Short description of the changes
- Update logic to extract OTLP data types to traverse kv lists instead of always encoding as JSON string, with a max depth of 5
- Expose `AddAttributesToMap` as a public function so consumers can use directly
- Update log translation to set the `body` field with a JSON string of the attribute to preserve backwards compatibility
- Removes unused & broken truncation event fields