### PR TITLE
feat: Add tracing support

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -422,20 +422,24 @@ func getMarshallableValue(value *common.AnyValue) interface{} {
 // kvlist attributes are flattened to a depth of (maxDepth), if the depth is exceeded, the attribute is added as a JSON string.
 // Bytes and array values are always added as JSON strings.
 func addAttributeToMap(ctx context.Context, result map[string]interface{}, key string, value *common.AnyValue, depth int) {
-	husky.AddAttributes(ctx, map[string]interface{}{"depth": depth})
-
 	switch value.Value.(type) {
 	case *common.AnyValue_StringValue:
+		husky.AddAttributes(ctx, map[string]interface{}{key + ".type": "string"})
 		result[key] = value.GetStringValue()
 	case *common.AnyValue_BoolValue:
+		husky.AddAttributes(ctx, map[string]interface{}{key + ".type": "bool"})
 		result[key] = value.GetBoolValue()
 	case *common.AnyValue_DoubleValue:
+		husky.AddAttributes(ctx, map[string]interface{}{key + "type": "double"})
 		result[key] = value.GetDoubleValue()
 	case *common.AnyValue_IntValue:
+		husky.AddAttributes(ctx, map[string]interface{}{key + "type": "int"})
 		result[key] = value.GetIntValue()
 	case *common.AnyValue_BytesValue, *common.AnyValue_ArrayValue:
+		husky.AddAttributes(ctx, map[string]interface{}{key + "type": "string"})
 		addAttributeToMapAsJson(result, key, value)
 	case *common.AnyValue_KvlistValue:
+		husky.AddAttributes(ctx, map[string]interface{}{key + "type": "string"})
 		for _, entry := range value.GetKvlistValue().Values {
 			k := key + "." + entry.Key
 			if depth < maxDepth {

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -438,7 +438,10 @@ func addAttributeToMap(ctx context.Context, result map[string]interface{}, key s
 		husky.AddAttributes(ctx, map[string]interface{}{"received_array_attr_type": true})
 		addAttributeToMapAsJson(result, key, value)
 	case *common.AnyValue_KvlistValue:
-		husky.AddAttributes(ctx, map[string]interface{}{"kvlist_max_depth": depth})
+		husky.AddAttributes(ctx, map[string]interface{}{
+			"received_kvlist_attr_type": true,
+			"kvlist_max_depth":          depth,
+		})
 		for _, entry := range value.GetKvlistValue().Values {
 			k := key + "." + entry.Key
 			if depth < maxDepth {

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -432,13 +432,13 @@ func addAttributeToMap(ctx context.Context, result map[string]interface{}, key s
 	case *common.AnyValue_IntValue:
 		result[key] = value.GetIntValue()
 	case *common.AnyValue_BytesValue:
-		husky.SetAttributes(ctx, map[string]interface{}{"received_bytes_attr_type": true})
+		husky.AddAttributes(ctx, map[string]interface{}{"received_bytes_attr_type": true})
 		addAttributeToMapAsJson(result, key, value)
 	case *common.AnyValue_ArrayValue:
-		husky.SetAttributes(ctx, map[string]interface{}{"received_array_attr_type": true})
+		husky.AddAttributes(ctx, map[string]interface{}{"received_array_attr_type": true})
 		addAttributeToMapAsJson(result, key, value)
 	case *common.AnyValue_KvlistValue:
-		husky.SetAttributes(ctx, map[string]interface{}{"kvlist_max_depth": depth})
+		husky.AddAttributes(ctx, map[string]interface{}{"kvlist_max_depth": depth})
 		for _, entry := range value.GetKvlistValue().Values {
 			k := key + "." + entry.Key
 			if depth < maxDepth {

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -424,22 +424,21 @@ func getMarshallableValue(value *common.AnyValue) interface{} {
 func addAttributeToMap(ctx context.Context, result map[string]interface{}, key string, value *common.AnyValue, depth int) {
 	switch value.Value.(type) {
 	case *common.AnyValue_StringValue:
-		husky.AddAttributes(ctx, map[string]interface{}{key + ".type": "string"})
 		result[key] = value.GetStringValue()
 	case *common.AnyValue_BoolValue:
-		husky.AddAttributes(ctx, map[string]interface{}{key + ".type": "bool"})
 		result[key] = value.GetBoolValue()
 	case *common.AnyValue_DoubleValue:
-		husky.AddAttributes(ctx, map[string]interface{}{key + "type": "double"})
 		result[key] = value.GetDoubleValue()
 	case *common.AnyValue_IntValue:
-		husky.AddAttributes(ctx, map[string]interface{}{key + "type": "int"})
 		result[key] = value.GetIntValue()
-	case *common.AnyValue_BytesValue, *common.AnyValue_ArrayValue:
-		husky.AddAttributes(ctx, map[string]interface{}{key + "type": "string"})
+	case *common.AnyValue_BytesValue:
+		husky.SetAttributes(ctx, map[string]interface{}{"received_bytes_attr_type": true})
+		addAttributeToMapAsJson(result, key, value)
+	case *common.AnyValue_ArrayValue:
+		husky.SetAttributes(ctx, map[string]interface{}{"received_array_attr_type": true})
 		addAttributeToMapAsJson(result, key, value)
 	case *common.AnyValue_KvlistValue:
-		husky.AddAttributes(ctx, map[string]interface{}{key + "type": "string"})
+		husky.SetAttributes(ctx, map[string]interface{}{"kvlist_max_depth": depth})
 		for _, entry := range value.GetKvlistValue().Values {
 			k := key + "." + entry.Key
 			if depth < maxDepth {

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -279,25 +279,25 @@ func getValueFromMetadata(md metadata.MD, key string) string {
 // Supported types are string, bool, double, int, bytes, array, and kvlist.
 // kvlist attributes are flattened to a depth of (maxDepth), if the depth is exceeded, the attribute is added as a JSON string.
 // Bytes and array values are always added as JSON strings.
-func AddAttributesToMap(attrs map[string]interface{}, attributes []*common.KeyValue) {
+func AddAttributesToMap(ctx context.Context, attrs map[string]interface{}, attributes []*common.KeyValue) {
 	for _, attr := range attributes {
 		// ignore entries if the key is empty or value is nil
 		if attr.Key == "" || attr.Value == nil {
 			continue
 		}
-		addAttributeToMap(attrs, attr.Key, attr.Value, 0)
+		addAttributeToMap(ctx, attrs, attr.Key, attr.Value, 0)
 	}
 }
 
-func getResourceAttributes(resource *resource.Resource) map[string]interface{} {
+func getResourceAttributes(ctx context.Context, resource *resource.Resource) map[string]interface{} {
 	attrs := map[string]interface{}{}
 	if resource != nil {
-		AddAttributesToMap(attrs, resource.Attributes)
+		AddAttributesToMap(ctx, attrs, resource.Attributes)
 	}
 	return attrs
 }
 
-func getScopeAttributes(scope *common.InstrumentationScope) map[string]interface{} {
+func getScopeAttributes(ctx context.Context, scope *common.InstrumentationScope) map[string]interface{} {
 	attrs := map[string]interface{}{}
 	if scope != nil {
 		if scope.Name != "" {
@@ -309,7 +309,7 @@ func getScopeAttributes(scope *common.InstrumentationScope) map[string]interface
 		if scope.Version != "" {
 			attrs["library.version"] = scope.Version
 		}
-		AddAttributesToMap(attrs, scope.Attributes)
+		AddAttributesToMap(ctx, attrs, scope.Attributes)
 	}
 	return attrs
 }
@@ -421,8 +421,8 @@ func getMarshallableValue(value *common.AnyValue) interface{} {
 // Supported types are string, bool, double, int, bytes, array, and kvlist.
 // kvlist attributes are flattened to a depth of (maxDepth), if the depth is exceeded, the attribute is added as a JSON string.
 // Bytes and array values are always added as JSON strings.
-func addAttributeToMap(result map[string]interface{}, key string, value *common.AnyValue, depth int) {
-	husky.AddAttributes(context.Background(), map[string]interface{}{"depth": depth})
+func addAttributeToMap(ctx context.Context, result map[string]interface{}, key string, value *common.AnyValue, depth int) {
+	husky.AddAttributes(ctx, map[string]interface{}{"depth": depth})
 
 	switch value.Value.(type) {
 	case *common.AnyValue_StringValue:
@@ -439,7 +439,7 @@ func addAttributeToMap(result map[string]interface{}, key string, value *common.
 		for _, entry := range value.GetKvlistValue().Values {
 			k := key + "." + entry.Key
 			if depth < maxDepth {
-				addAttributeToMap(result, k, entry.Value, depth+1)
+				addAttributeToMap(ctx, result, k, entry.Value, depth+1)
 			} else {
 				addAttributeToMapAsJson(result, k, entry.Value)
 			}

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -432,13 +432,13 @@ func addAttributeToMap(ctx context.Context, result map[string]interface{}, key s
 	case *common.AnyValue_IntValue:
 		result[key] = value.GetIntValue()
 	case *common.AnyValue_BytesValue:
-		husky.AddAttributes(ctx, map[string]interface{}{"received_bytes_attr_type": true})
+		husky.AddTelemetryAttribute(ctx, "received_bytes_attr_type", true)
 		addAttributeToMapAsJson(result, key, value)
 	case *common.AnyValue_ArrayValue:
-		husky.AddAttributes(ctx, map[string]interface{}{"received_array_attr_type": true})
+		husky.AddTelemetryAttribute(ctx, "received_array_attr_type", true)
 		addAttributeToMapAsJson(result, key, value)
 	case *common.AnyValue_KvlistValue:
-		husky.AddAttributes(ctx, map[string]interface{}{
+		husky.AddTelemetryAttributes(ctx, map[string]interface{}{
 			"received_kvlist_attr_type": true,
 			"kvlist_max_depth":          depth,
 		})

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/honeycombio/husky"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/zstd"
 	collectorlogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
@@ -420,6 +422,8 @@ func getMarshallableValue(value *common.AnyValue) interface{} {
 // kvlist attributes are flattened to a depth of (maxDepth), if the depth is exceeded, the attribute is added as a JSON string.
 // Bytes and array values are always added as JSON strings.
 func addAttributeToMap(result map[string]interface{}, key string, value *common.AnyValue, depth int) {
+	husky.AddAttributes(context.Background(), map[string]interface{}{"depth": depth})
+
 	switch value.Value.(type) {
 	case *common.AnyValue_StringValue:
 		result[key] = value.GetStringValue()

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -107,7 +107,7 @@ func TestAddAttributesToMap(t *testing.T) {
 
 	for _, tc := range testCases {
 		attrs := map[string]interface{}{}
-		AddAttributesToMap(attrs, []*common.KeyValue{tc.attribute})
+		AddAttributesToMap(context.Background(), attrs, []*common.KeyValue{tc.attribute})
 		assert.Equal(t, tc.expected, attrs)
 	}
 }
@@ -393,7 +393,7 @@ func Test_getValue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			attrs := map[string]interface{}{}
-			addAttributeToMap(attrs, "body", tt.value, 0)
+			addAttributeToMap(context.Background(), attrs, "body", tt.value, 0)
 			assert.Equal(t, tt.want, attrs)
 		})
 	}

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"github.com/honeycombio/husky"
 	"io"
 	"math"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/honeycombio/husky"
 
 	"github.com/honeycombio/husky/test"
 	"github.com/stretchr/testify/assert"
@@ -1233,7 +1234,7 @@ func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {
 
 func TestArrayAttributesCallsConfiguredSetAttributesFunc(t *testing.T) {
 	called := false
-	husky.SetAttributesFunc = func(ctx context.Context, values map[string]any) {
+	husky.SetAddAttributesFunc = func(ctx context.Context, values map[string]any) {
 		called = true
 	}
 	fields := map[string]interface{}{}

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1233,7 +1233,7 @@ func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {
 
 func TestGetInstrumentationLibraryNameAndVersion(t *testing.T) {
 	called := false
-	husky.TracingFunc = func(ctx context.Context, values map[string]any) {
+	husky.SetAttributesFunc = func(ctx context.Context, values map[string]any) {
 		called = true
 	}
 	attrs := map[string]interface{}{}

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1231,13 +1231,23 @@ func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {
 	}
 }
 
-func TestGetInstrumentationLibraryNameAndVersion(t *testing.T) {
+func TestArrayAttributesCallsConfiguredSetAttributesFunc(t *testing.T) {
 	called := false
 	husky.SetAttributesFunc = func(ctx context.Context, values map[string]any) {
 		called = true
 	}
-	attrs := map[string]interface{}{}
-	attr := &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "test"}}
-	addAttributeToMap(context.Background(), attrs, "key", attr, 0)
+	fields := map[string]interface{}{}
+	attr := &common.AnyValue{
+		Value: &common.AnyValue_ArrayValue{
+			ArrayValue: &common.ArrayValue{
+				Values: []*common.AnyValue{
+					{
+						Value: &common.AnyValue_StringValue{StringValue: "io.opentelemetry.tomcat-7.0"},
+					},
+				},
+			},
+		},
+	}
+	addAttributeToMap(context.Background(), fields, "key", attr, 0)
 	assert.True(t, called)
 }

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1313,10 +1313,8 @@ func TestOtlpAttributesRecordsAttribueType(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			telemetryFields := map[string]interface{}{}
-			husky.SetAddAttributesFunc = func(ctx context.Context, values map[string]any) {
-				for k, v := range values {
-					telemetryFields[k] = v
-				}
+			husky.AddTelemetryAttributeFunc = func(ctx context.Context, key string, value any) {
+				telemetryFields[key] = value
 			}
 
 			eventFields := map[string]interface{}{}

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -2,7 +2,9 @@ package otlp
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
+	"github.com/honeycombio/husky"
 	"io"
 	"math"
 	"strconv"
@@ -1227,4 +1229,15 @@ func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {
 			assert.Equal(t, test.isInstrumentationLibrary, isInstrumentationLibrary(test.libraryName))
 		})
 	}
+}
+
+func TestGetInstrumentationLibraryNameAndVersion(t *testing.T) {
+	called := false
+	husky.TracingFunc = func(ctx context.Context, values map[string]any) {
+		called = true
+	}
+	attrs := map[string]interface{}{}
+	attr := &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "test"}}
+	addAttributeToMap(attrs, "key", attr, 0)
+	assert.True(t, called)
 }

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -134,7 +134,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.Name, func(t *testing.T) {
 
-			result, err := TranslateTraceRequest(req, tC.ri)
+			result, err := TranslateTraceRequest(context.Background(), req, tC.ri)
 			assert.Nil(t, err)
 			assert.Equal(t, proto.Size(req), result.RequestSize)
 			assert.Equal(t, 1, len(result.Batches))
@@ -306,7 +306,7 @@ func TestTranslateException(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.Name, func(t *testing.T) {
 
-			result, err := TranslateTraceRequest(req, tC.ri)
+			result, err := TranslateTraceRequest(context.Background(), req, tC.ri)
 			assert.Nil(t, err)
 			assert.Equal(t, proto.Size(req), result.RequestSize)
 			assert.Equal(t, 1, len(result.Batches))
@@ -395,7 +395,7 @@ func TestTranslateGrpcTraceRequestFromMultipleServices(t *testing.T) {
 		}},
 	}
 
-	result, err := TranslateTraceRequest(req, ri)
+	result, err := TranslateTraceRequest(context.Background(), req, ri)
 	assert.Nil(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
 	assert.Equal(t, 2, len(result.Batches))
@@ -464,7 +464,7 @@ func TestTranslateGrpcTraceRequestFromMultipleLibraries(t *testing.T) {
 		}},
 	}
 
-	result, err := TranslateTraceRequest(req, ri)
+	result, err := TranslateTraceRequest(context.Background(), req, ri)
 	assert.NoError(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
 	assert.Equal(t, 1, len(result.Batches))
@@ -588,7 +588,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 							body, err := prepareOtlpRequestHttpBody(req, testCaseContentType, testCaseContentEncoding)
 							require.NoError(t, err, "Womp womp. Ought to have been able to turn the OTLP trace request into an HTTP body.")
 
-							result, err := TranslateTraceRequestFromReader(io.NopCloser(strings.NewReader(body)), tC.ri)
+							result, err := TranslateTraceRequestFromReader(context.Background(), io.NopCloser(strings.NewReader(body)), tC.ri)
 							assert.Nil(t, err)
 							assert.Equal(t, proto.Size(req), result.RequestSize)
 							assert.Equal(t, 1, len(result.Batches))
@@ -690,7 +690,7 @@ func TestTranslateHttpTraceRequestFromMultipleServices(t *testing.T) {
 		ContentType: "application/protobuf",
 	}
 
-	result, err := TranslateTraceRequestFromReader(body, ri)
+	result, err := TranslateTraceRequestFromReader(context.Background(), body, ri)
 	assert.Nil(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
 	assert.Equal(t, 2, len(result.Batches))
@@ -719,7 +719,7 @@ func TestInvalidContentTypeReturnsError(t *testing.T) {
 		ContentType: "application/binary",
 	}
 
-	result, err := TranslateTraceRequestFromReader(body, ri)
+	result, err := TranslateTraceRequestFromReader(context.Background(), body, ri)
 	assert.Nil(t, result)
 	assert.Equal(t, ErrInvalidContentType, err)
 }
@@ -733,7 +733,7 @@ func TestInvalidBodyReturnsError(t *testing.T) {
 		ContentType: "application/protobuf",
 	}
 
-	result, err := TranslateTraceRequestFromReader(body, ri)
+	result, err := TranslateTraceRequestFromReader(context.Background(), body, ri)
 	assert.Nil(t, result)
 	assert.Equal(t, ErrFailedParseBody, err)
 }
@@ -890,7 +890,7 @@ func TestDefaultServiceNameApplied(t *testing.T) {
 				ContentType: "application/protobuf",
 			}
 
-			result, err := TranslateTraceRequest(req, ri)
+			result, err := TranslateTraceRequest(context.Background(), req, ri)
 			assert.Nil(t, err)
 			batch := result.Batches[0]
 			assert.NotNil(t, batch.Dataset)
@@ -963,7 +963,7 @@ func TestUnknownServiceNameIsTruncatedForDataset(t *testing.T) {
 				ContentType: "application/protobuf",
 			}
 
-			result, err := TranslateTraceRequestFromReader(body, ri)
+			result, err := TranslateTraceRequestFromReader(context.Background(), body, ri)
 			assert.Nil(t, err)
 
 			assert.Equal(t, 1, len(result.Batches))
@@ -1030,7 +1030,7 @@ func TestServiceNameIsTrimmedForDataset(t *testing.T) {
 				ContentType: "application/protobuf",
 			}
 
-			result, err := TranslateTraceRequest(req, ri)
+			result, err := TranslateTraceRequest(context.Background(), req, ri)
 			assert.Nil(t, err)
 
 			assert.Equal(t, 1, len(result.Batches))
@@ -1106,7 +1106,7 @@ func TestBadTraceRequest(t *testing.T) {
 					ContentEncoding: encoding,
 				}
 
-				_, err := TranslateTraceRequestFromReader(body, ri)
+				_, err := TranslateTraceRequestFromReader(context.Background(), body, ri)
 				assert.NotNil(t, err)
 				assert.Equal(t, ErrFailedParseBody, err)
 			})
@@ -1155,7 +1155,7 @@ func TestInstrumentationLibrarySpansHaveAttributeAdded(t *testing.T) {
 		}},
 	}
 
-	result, err := TranslateTraceRequest(req, ri)
+	result, err := TranslateTraceRequest(context.Background(), req, ri)
 	assert.NoError(t, err)
 	assert.Equal(t, proto.Size(req), result.RequestSize)
 	assert.Equal(t, 1, len(result.Batches))
@@ -1238,6 +1238,6 @@ func TestGetInstrumentationLibraryNameAndVersion(t *testing.T) {
 	}
 	attrs := map[string]interface{}{}
 	attr := &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "test"}}
-	addAttributeToMap(attrs, "key", attr, 0)
+	addAttributeToMap(context.Background(), attrs, "key", attr, 0)
 	assert.True(t, called)
 }

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1253,7 +1253,7 @@ func TestOtlpAttributesRecordsAttribueType(t *testing.T) {
 				},
 			},
 			eventFields: map[string]interface{}{
-				"key": "[\"io.opentelemetry.tomcat-7.0\"]\n",
+				"attr": "[\"io.opentelemetry.tomcat-7.0\"]\n",
 			},
 			telemetryFields: map[string]interface{}{
 				"received_array_attr_type": true,
@@ -1267,10 +1267,45 @@ func TestOtlpAttributesRecordsAttribueType(t *testing.T) {
 				},
 			},
 			eventFields: map[string]interface{}{
-				"key": "\"ZGF0YQ==\"\n",
+				"attr": "\"ZGF0YQ==\"\n",
 			},
 			telemetryFields: map[string]interface{}{
 				"received_bytes_attr_type": true,
+			},
+		},
+		{
+			name: "kvlist",
+			attr: &common.AnyValue{
+				Value: &common.AnyValue_KvlistValue{
+					KvlistValue: &common.KeyValueList{
+						Values: []*common.KeyValue{
+							{
+								Key: "custom",
+								Value: &common.AnyValue{
+									Value: &common.AnyValue_KvlistValue{
+										KvlistValue: &common.KeyValueList{
+											Values: []*common.KeyValue{
+												{
+													Key: "name",
+													Value: &common.AnyValue{
+														Value: &common.AnyValue_StringValue{StringValue: "value"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			eventFields: map[string]interface{}{
+				"attr.custom.name": "value",
+			},
+			telemetryFields: map[string]interface{}{
+				"received_kvlist_attr_type": true,
+				"kvlist_max_depth":          1,
 			},
 		},
 	}
@@ -1285,7 +1320,7 @@ func TestOtlpAttributesRecordsAttribueType(t *testing.T) {
 			}
 
 			eventFields := map[string]interface{}{}
-			addAttributeToMap(context.Background(), eventFields, "key", tc.attr, 0)
+			addAttributeToMap(context.Background(), eventFields, "attr", tc.attr, 0)
 			assert.Equal(t, tc.eventFields, eventFields)
 			assert.Equal(t, tc.telemetryFields, telemetryFields)
 		})

--- a/telemetry.go
+++ b/telemetry.go
@@ -2,10 +2,15 @@ package husky
 
 import "context"
 
-var TracingFunc func(ctx context.Context, attributes map[string]any) = nil
+// SetAttributesFunc is a function that can be used to set attributes in telemetry controlled
+// by users of this package.
+// For example, beeline users would use beeline.AddField and OTel users would use span.SetAttributes.
+var SetAttributesFunc func(ctx context.Context, attributes map[string]any) = nil
 
-func AddAttributes(ctx context.Context, attributes map[string]any) {
-	if TracingFunc != nil {
-		TracingFunc(ctx, attributes)
+// SetAttributes is used internally to set attributes using the configured SetAttributesFunc.
+// This function is not intended to be used directly by consumers of this package.
+func SetAttributes(ctx context.Context, attributes map[string]any) {
+	if SetAttributesFunc != nil {
+		SetAttributesFunc(ctx, attributes)
 	}
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -1,0 +1,11 @@
+package husky
+
+import "context"
+
+var TracingFunc func(ctx context.Context, attributes map[string]any) = nil
+
+func AddAttributes(ctx context.Context, attributes map[string]any) {
+	if TracingFunc != nil {
+		TracingFunc(ctx, attributes)
+	}
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -2,15 +2,15 @@ package husky
 
 import "context"
 
-// SetAttributesFunc is a function that can be used to set attributes in telemetry controlled
+// SetAddAttributesFunc is used to provide a function that adds attributes to telemetry controlled
 // by users of this package.
 // For example, beeline users would use beeline.AddField and OTel users would use span.SetAttributes.
-var SetAttributesFunc func(ctx context.Context, attributes map[string]any) = nil
+var SetAddAttributesFunc func(ctx context.Context, attributes map[string]any) = nil
 
-// SetAttributes is used internally to set attributes using the configured SetAttributesFunc.
+// AddAttributes is used internally to set attributes using the configured SetAddAttributesFunc.
 // This function is not intended to be used directly by consumers of this package.
-func SetAttributes(ctx context.Context, attributes map[string]any) {
-	if SetAttributesFunc != nil {
-		SetAttributesFunc(ctx, attributes)
+func AddAttributes(ctx context.Context, attributes map[string]any) {
+	if SetAddAttributesFunc != nil {
+		SetAddAttributesFunc(ctx, attributes)
 	}
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -2,15 +2,23 @@ package husky
 
 import "context"
 
-// SetAddAttributesFunc is used to provide a function that adds attributes to telemetry controlled
+// AddTelemetryAttributeFunc is used to provide a function that adds attributes to telemetry controlled
 // by users of this package.
 // For example, beeline users would use beeline.AddField and OTel users would use span.SetAttributes.
-var SetAddAttributesFunc func(ctx context.Context, attributes map[string]any) = nil
+var AddTelemetryAttributeFunc func(ctx context.Context, key string, value any) = nil
 
-// AddAttributes is used internally to set attributes using the configured SetAddAttributesFunc.
+// AddTelemetryAttribute is used internally to set attributes using the configured SetAddAttributesFunc.
 // This function is not intended to be used directly by consumers of this package.
-func AddAttributes(ctx context.Context, attributes map[string]any) {
-	if SetAddAttributesFunc != nil {
-		SetAddAttributesFunc(ctx, attributes)
+func AddTelemetryAttribute(ctx context.Context, key string, value any) {
+	if AddTelemetryAttributeFunc != nil {
+		AddTelemetryAttributeFunc(ctx, key, value)
+	}
+}
+
+// AddTelemetryAttributes is used internally to set multiple attributes using the configured SetAddAttributesFunc.
+// This function is not intended to be used directly by consumers of this package.
+func AddTelemetryAttributes(ctx context.Context, attributes map[string]any) {
+	for key, value := range attributes {
+		AddTelemetryAttribute(ctx, key, value)
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Adds tracing support to Husky that can be configured by library users (eg beeline or otel). This is done by exposing a new global var `AddTelemetryAttributeFunc` that husky will call internally. The new func receives a context struct and a map of attributes with the library responsible to setting that telemetry on whatever telemetry client being used.

For example, a library user may configure the beeline then set the `AddTelemetryAttributeFunc` to add the attributes to the current beeline span like this:

```golang
husky.AddTelemetryAttributeFunc = func(ctx context.Context, key string, value any) {
	beeline.AddField(ctx, key, value)
}
```

I would like to make husky just use OTel for tracing, but some consumers are still using beeline and I don’t want to add beeline as a dependency. 

## Short description of the changes
- Adds new `AddTelemetryAttributeFunc` that library users can set to receive telemetry fields about what husky is doing
- Updates all public funcs to also take a ctx object and pass along to internal funcs (eg `addAttributesToMap`)
- Set telemetry attributes when handling array, bytes or kvlist attributes
- Record the max depth of a kvlist as it's being traversed
- Add tests to verify telemetry attributes are called

