### PR TITLE
feat(husky): Add in time since span event start from start of span

### DIFF
--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -104,7 +104,6 @@ func TranslateTraceRequest(ctx context.Context, request *collectorTrace.ExportTr
 
 				for _, sevent := range span.Events {
 					timestamp := time.Unix(0, int64(sevent.TimeUnixNano)).UTC()
-
 					attrs := map[string]interface{}{
 						"trace.trace_id":       traceID,
 						"trace.parent_id":      spanID,
@@ -113,7 +112,7 @@ func TranslateTraceRequest(ctx context.Context, request *collectorTrace.ExportTr
 						"meta.annotation_type": "span_event",
 						"meta.signal_type":     "trace",
 					}
-
+					// calculate time since span start for querying capabilities
 					time_since_span_start := float64(sevent.TimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond)
 					if time_since_span_start < 0 {
 						time_since_span_start = 0

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -104,6 +104,7 @@ func TranslateTraceRequest(ctx context.Context, request *collectorTrace.ExportTr
 
 				for _, sevent := range span.Events {
 					timestamp := time.Unix(0, int64(sevent.TimeUnixNano)).UTC()
+
 					attrs := map[string]interface{}{
 						"trace.trace_id":       traceID,
 						"trace.parent_id":      spanID,
@@ -113,6 +114,12 @@ func TranslateTraceRequest(ctx context.Context, request *collectorTrace.ExportTr
 						"meta.signal_type":     "trace",
 					}
 
+					time_since_span_start := float64(sevent.TimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond)
+					if time_since_span_start < 0 {
+						time_since_span_start = 0
+						eventAttrs["meta.invalid_time_since_span_start"] = true
+					}
+					eventAttrs["meta.time_since_span_start"] = time_since_span_start
 					// copy resource & scope attributes then span event attributes
 					for k, v := range resourceAttrs {
 						attrs[k] = v

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -117,9 +117,9 @@ func TranslateTraceRequest(ctx context.Context, request *collectorTrace.ExportTr
 					time_since_span_start := float64(sevent.TimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond)
 					if time_since_span_start < 0 {
 						time_since_span_start = 0
-						eventAttrs["meta.invalid_time_since_span_start"] = true
+						attrs["meta.invalid_time_since_span_start"] = true
 					}
-					eventAttrs["meta.time_since_span_start"] = time_since_span_start
+					attrs["meta.time_since_span_start_ms"] = time_since_span_start
 					// copy resource & scope attributes then span event attributes
 					for k, v := range resourceAttrs {
 						attrs[k] = v

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -85,7 +85,8 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 						},
 					},
 					Events: []*trace.Span_Event{{
-						Name: "span_event",
+						Name:         "span_event",
+						TimeUnixNano: uint64(startTimestamp.Add(time.Millisecond * 1).Nanosecond()),
 						Attributes: []*common.KeyValue{{
 							Key: "span_event_attr",
 							Value: &common.AnyValue{
@@ -155,6 +156,7 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 			assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
 			assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+			assert.Equal(t, float64(1), ev.Attributes["meta.time_since_span_start_ms"])
 
 			// link
 			ev = events[1]
@@ -247,7 +249,8 @@ func TestTranslateException(t *testing.T) {
 						},
 					},
 					Events: []*trace.Span_Event{{
-						Name: "exception",
+						Name:         "exception",
+						TimeUnixNano: uint64(startTimestamp.Add(time.Millisecond * 1).Nanosecond()),
 						Attributes: []*common.KeyValue{
 							{
 								Key: "exception.type",
@@ -530,7 +533,8 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 						},
 					}},
 					Events: []*trace.Span_Event{{
-						Name: "span_event",
+						Name:         "span_event",
+						TimeUnixNano: uint64(startTimestamp.Add(time.Millisecond * 1).Nanosecond()),
 						Attributes: []*common.KeyValue{{
 							Key: "span_event_attr",
 							Value: &common.AnyValue{
@@ -608,6 +612,7 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 							assert.Equal(t, "span_event", ev.Attributes["meta.annotation_type"])
 							assert.Equal(t, "span_event_attr_val", ev.Attributes["span_event_attr"])
 							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
+							assert.Equal(t, float64(1), ev.Attributes["meta.time_since_span_start_ms"])
 
 							// link
 							ev = events[1]


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
It would be useful to know how long after the event happened from the span start e.g. opening and closing connection events. By adding this attribute, it becomes something a user could query.
-

## Short description of the changes
Calculate time diff of span event time vs span start time.
-

