### PR TITLE
fix: Ensure a limited reader is used when decompressing payloads

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -471,7 +471,7 @@ func addAttributeToMapAsJson(attrs map[string]interface{}, key string, value *co
 	return w.truncatedBytes
 }
 
-func parseOtlpRequestBody(body io.ReadCloser, contentType string, contentEncoding string, request protoreflect.ProtoMessage) error {
+func parseOtlpRequestBody(body io.ReadCloser, contentType string, contentEncoding string, request protoreflect.ProtoMessage, maxRequestBodySize int64) error {
 	defer func() {
 		_ = body.Close()
 	}()
@@ -480,7 +480,7 @@ func parseOtlpRequestBody(body io.ReadCloser, contentType string, contentEncodin
 	if err != nil {
 		return err
 	}
-	bodyReader := io.LimitReader(bytes.NewReader(bodyBytes), defaultMaxRequestBodySize)
+	bodyReader := io.LimitReader(bytes.NewReader(bodyBytes), maxRequestBodySize)
 
 	var reader io.Reader
 	switch contentEncoding {

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 func TestParseGrpcMetadataIntoRequestInfo(t *testing.T) {
@@ -762,10 +762,8 @@ func Test_BytesToSpanID(t *testing.T) {
 }
 
 func Test_ReadOtlpBodyTooLarge(t *testing.T) {
-	var body io.ReadCloser
-	contentType := "application/protobuf"
-	contentEncoding := "gzip"
-	var request protoreflect.ProtoMessage
-	err := parseOtlpRequestBody(body, contentType, contentEncoding, request)
+	body := io.NopCloser(strings.NewReader(string([]byte(strings.Repeat("a", 1000*1000*21)))))
+	request := &collectorlogs.ExportLogsServiceRequest{}
+	err := parseOtlpRequestBody(body, "application/protobuf", "other", request)
 	require.Error(t, err)
 }

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	collectorlogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -18,6 +19,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 func TestParseGrpcMetadataIntoRequestInfo(t *testing.T) {
@@ -757,4 +759,13 @@ func Test_BytesToSpanID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ReadOtlpBodyTooLarge(t *testing.T) {
+	var body io.ReadCloser
+	contentType := "application/protobuf"
+	contentEncoding := "gzip"
+	var request protoreflect.ProtoMessage
+	err := parseOtlpRequestBody(body, contentType, contentEncoding, request)
+	require.Error(t, err)
 }

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -17,7 +17,7 @@ func TranslateLogsRequestFromReader(ctx context.Context, body io.ReadCloser, ri 
 		return nil, err
 	}
 	request := &collectorLogs.ExportLogsServiceRequest{}
-	if err := parseOtlpRequestBody(body, ri.ContentType, ri.ContentEncoding, request); err != nil {
+	if err := parseOtlpRequestBody(body, ri.ContentType, ri.ContentEncoding, request, defaultMaxRequestBodySize); err != nil {
 		return nil, ErrFailedParseBody
 	}
 	return TranslateLogsRequest(ctx, request, ri)

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -28,7 +28,7 @@ func TranslateTraceRequestFromReader(ctx context.Context, body io.ReadCloser, ri
 		return nil, err
 	}
 	request := &collectorTrace.ExportTraceServiceRequest{}
-	if err := parseOtlpRequestBody(body, ri.ContentType, ri.ContentEncoding, request); err != nil {
+	if err := parseOtlpRequestBody(body, ri.ContentType, ri.ContentEncoding, request, defaultMaxRequestBodySize); err != nil {
 		return nil, ErrFailedParseBody
 	}
 	return TranslateTraceRequest(ctx, request, ri)


### PR DESCRIPTION
## Which problem is this PR solving?

- Highly compressed payloads could cause memory pressure because of unchecked sizes in the reader.

## Short description of the changes

- applies a LimitReader with a default of 20MiB