### PR TITLE
feat: 🌓🚀 add a utility attr name-to-description lookup function

### DIFF
--- a/otlp/semconv.go
+++ b/otlp/semconv.go
@@ -7,6 +7,16 @@ func GetDescriptionForOtelAttributeName(name string) string {
 		return "HTTP request method."
 	case "http.request.header":
 		return "HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values."
+	case "http.request.method_original":
+		return "Original HTTP method sent by the client in the request line."
+	case "http.request.resend_count":
+		return "The ordinal number of request resending attempt (for any reason, including redirects)."
+	case "http.response.header":
+		return "HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values."
+	case "http.response.status_code":
+		return "[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6)."
+	case "http.route":
+		return "The matched route, that is, the path template in the format used by the respective server framework."
 	default:
 		return ""
 	}

--- a/otlp/semconv.go
+++ b/otlp/semconv.go
@@ -1,0 +1,16 @@
+package otlp
+
+func GetDescriptionForOtelAttributeName(name string) string {
+	switch name {
+	case "http.request.method":
+		return "HTTP request method."
+	case "http.request.header":
+		return "HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values."
+	case "http.response.body.size":
+		return "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and" +
+			"is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)" +
+			"header. For requests using transport encoding, this should be the compressed size."
+	default:
+		return ""
+	}
+}

--- a/otlp/semconv.go
+++ b/otlp/semconv.go
@@ -6,10 +6,6 @@ func GetDescriptionForOtelAttributeName(name string) string {
 		return "HTTP request method."
 	case "http.request.header":
 		return "HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values."
-	case "http.response.body.size":
-		return "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and" +
-			"is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)" +
-			"header. For requests using transport encoding, this should be the compressed size."
 	default:
 		return ""
 	}

--- a/otlp/semconv.go
+++ b/otlp/semconv.go
@@ -1,5 +1,6 @@
 package otlp
 
+// GetDescriptionForOtelAttributeName returns an informative description of a given OpenTelemetry attribute name.
 func GetDescriptionForOtelAttributeName(name string) string {
 	switch name {
 	case "http.request.method":

--- a/otlp/semconv.go
+++ b/otlp/semconv.go
@@ -1,23 +1,20 @@
 package otlp
 
+var descriptions = map[string]string{
+	"http.request.method":          "HTTP request method.",
+	"http.request.header":          "HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.",
+	"http.request.method_original": "Original HTTP method sent by the client in the request line.",
+	"http.request.resend_count":    "The ordinal number of request resending attempt (for any reason, including redirects).",
+	"http.response.header":         "HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.",
+	"http.response.status_code":    "[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).",
+	"http.route":                   "The matched route, that is, the path template in the format used by the respective server framework.",
+}
+
 // GetDescriptionForOtelAttributeName returns an informative description of a given OpenTelemetry attribute name.
 func GetDescriptionForOtelAttributeName(name string) string {
-	switch name {
-	case "http.request.method":
-		return "HTTP request method."
-	case "http.request.header":
-		return "HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values."
-	case "http.request.method_original":
-		return "Original HTTP method sent by the client in the request line."
-	case "http.request.resend_count":
-		return "The ordinal number of request resending attempt (for any reason, including redirects)."
-	case "http.response.header":
-		return "HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values."
-	case "http.response.status_code":
-		return "[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6)."
-	case "http.route":
-		return "The matched route, that is, the path template in the format used by the respective server framework."
-	default:
-		return ""
+	if description, ok := descriptions[name]; ok {
+		return description
 	}
+
+	return ""
 }

--- a/otlp/semconv_test.go
+++ b/otlp/semconv_test.go
@@ -41,6 +41,7 @@ func TestGetDescriptionForOtelAttributeName(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.attrName, func(t *testing.T) {
 			assert.Equal(t, tC.expectedDescription, GetDescriptionForOtelAttributeName(tC.attrName))
+			assert.LessOrEqual(t, len(GetDescriptionForOtelAttributeName(tC.attrName)), 255, "Description is limited to 255 characters.")
 		})
 	}
 }

--- a/otlp/semconv_test.go
+++ b/otlp/semconv_test.go
@@ -16,18 +16,26 @@ func TestGetDescriptionForOtelAttributeName(t *testing.T) {
 			expectedDescription: "",
 		},
 		{
-			attrName:            "http.request.method",
-			expectedDescription: "HTTP request method.",
-		},
-		{
 			attrName:            "http.request.header",
 			expectedDescription: "HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.",
-		},
-		{
-			attrName: "http.response.body.size",
-			expectedDescription: "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and" +
-				"is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)" +
-				"header. For requests using transport encoding, this should be the compressed size.",
+		}, {
+			attrName:            "http.request.method",
+			expectedDescription: "HTTP request method.",
+		}, {
+			attrName:            "http.request.method_original",
+			expectedDescription: "Original HTTP method sent by the client in the request line.",
+		}, {
+			attrName:            "http.request.resend_count",
+			expectedDescription: "The ordinal number of request resending attempt (for any reason, including redirects).",
+		}, {
+			attrName:            "http.response.header",
+			expectedDescription: "HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.",
+		}, {
+			attrName:            "http.response.status_code",
+			expectedDescription: "[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).",
+		}, {
+			attrName:            "http.route",
+			expectedDescription: "The matched route, that is, the path template in the format used by the respective server framework.",
 		},
 	}
 	for _, tC := range testCases {

--- a/otlp/semconv_test.go
+++ b/otlp/semconv_test.go
@@ -1,0 +1,38 @@
+package otlp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDescriptionForOtelAttributeName(t *testing.T) {
+	testCases := []struct {
+		attrName            string
+		expectedDescription string
+	}{
+		{
+			attrName:            "some.random.attribute",
+			expectedDescription: "",
+		},
+		{
+			attrName:            "http.request.method",
+			expectedDescription: "HTTP request method.",
+		},
+		{
+			attrName:            "http.request.header",
+			expectedDescription: "HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.",
+		},
+		{
+			attrName: "http.response.body.size",
+			expectedDescription: "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and" +
+				"is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)" +
+				"header. For requests using transport encoding, this should be the compressed size.",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.attrName, func(t *testing.T) {
+			assert.Equal(t, tC.expectedDescription, GetDescriptionForOtelAttributeName(tC.attrName))
+		})
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Help folks know what an OTel attribute means.

## Short description of the changes

The first baby steps toward showing a description for a recognized attribute. Look up names that match stable OpenTelemetry semantic conventions and return a reasonable description. The descriptions in this PR are pulled from the semconv "brief" associated with each attribute.

## The Future

- We expect to continue using the OTel semconv brief for each _stable_ attribute name.
- Generate this lookup from [the semconv models](https://github.com/open-telemetry/semantic-conventions/tree/main/model)?
