### PR TITLE
maint: appease codeql warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/husky
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/json-iterator/go v1.1.12


### PR DESCRIPTION
## Which problem is this PR solving?

The following warning is triggered by CodeQL scanning: "As of Go 1.21, toolchain versions must use the 1.N.P syntax." as per https://go.dev/doc/toolchain#version

## Short description of the changes

- updated go.mod file to include the patch version as well. used .0 to remain compatible with all versions of go 1.21

