### PR TITLE
feat: add sample rate to logs if set

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -631,7 +631,7 @@ func getSampleRate(attrs map[string]interface{}) int32 {
 	}
 	// To make sampleRate consistent between Otel and Honeycomb, we coerce all 0 values to 1 here.
 	// Negative values are also invalid and so we convert to 1
-	if sampleRate == 0 || sampleRate < 0 {
+	if sampleRate <= 0 {
 		sampleRate = defaultSampleRate
 	}
 	delete(attrs, sampleRateKey) // remove attr

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -584,8 +584,8 @@ func shouldTrimTraceId(traceID []byte) bool {
 	return true
 }
 
-func GetSampleRate(attrs map[string]interface{}) int32 {
-	sampleRateKey := GetSampleRateKey(attrs)
+func getSampleRate(attrs map[string]interface{}) int32 {
+	sampleRateKey := getSampleRateKey(attrs)
 	if sampleRateKey == "" {
 		return defaultSampleRate
 	}
@@ -626,7 +626,7 @@ func GetSampleRate(attrs map[string]interface{}) int32 {
 	return sampleRate
 }
 
-func GetSampleRateKey(attrs map[string]interface{}) string {
+func getSampleRateKey(attrs map[string]interface{}) string {
 	if _, ok := attrs["sampleRate"]; ok {
 		return "sampleRate"
 	}

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -594,11 +594,11 @@ func getSampleRate(attrs map[string]interface{}) int32 {
 	switch v := sampleRateVal.(type) {
 	case string:
 		if i, err := strconv.ParseFloat(v, 64); err == nil {
-			j := int(i + 0.5)
-			if j < math.MaxInt32 {
-				sampleRate = int32(j)
-			} else {
+			if i >= float64(math.MaxInt32) {
 				sampleRate = math.MaxInt32
+			} else {
+				j := int(i + 0.5)
+				sampleRate = int32(j)
 			}
 		}
 	case int32:

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -783,7 +783,7 @@ func TestNoSampleRateKeyReturnOne(t *testing.T) {
 	attrs := map[string]interface{}{
 		"not_a_sample_rate": 10,
 	}
-	sampleRate := GetSampleRate(attrs)
+	sampleRate := getSampleRate(attrs)
 	assert.Equal(t, int32(1), sampleRate)
 }
 
@@ -792,14 +792,14 @@ func TestCanDetectSampleRateCapitalizations(t *testing.T) {
 		attrs := map[string]interface{}{
 			"sampleRate": 10,
 		}
-		key := GetSampleRateKey(attrs)
+		key := getSampleRateKey(attrs)
 		assert.Equal(t, "sampleRate", key)
 	})
 	t.Run("uppercase", func(t *testing.T) {
 		attrs := map[string]interface{}{
 			"SampleRate": 10,
 		}
-		key := GetSampleRateKey(attrs)
+		key := getSampleRateKey(attrs)
 		assert.Equal(t, "SampleRate", key)
 	})
 }
@@ -839,7 +839,7 @@ func TestGetSampleRateConversions(t *testing.T) {
 		attrs := map[string]interface{}{
 			"sampleRate": tc.sampleRate,
 		}
-		assert.Equal(t, tc.expected, GetSampleRate(attrs))
+		assert.Equal(t, tc.expected, getSampleRate(attrs))
 		assert.Equal(t, 0, len(attrs))
 	}
 }

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -788,20 +788,23 @@ func TestNoSampleRateKeyReturnOne(t *testing.T) {
 }
 
 func TestCanDetectSampleRateCapitalizations(t *testing.T) {
-	t.Run("lowercase", func(t *testing.T) {
-		attrs := map[string]interface{}{
-			"sampleRate": 10,
-		}
-		key := getSampleRateKey(attrs)
-		assert.Equal(t, "sampleRate", key)
-	})
-	t.Run("uppercase", func(t *testing.T) {
-		attrs := map[string]interface{}{
-			"SampleRate": 10,
-		}
-		key := getSampleRateKey(attrs)
-		assert.Equal(t, "SampleRate", key)
-	})
+	tests := []struct {
+		name  string
+		attrs map[string]interface{}
+	}{
+		{"lowercase", map[string]interface{}{"samplerate": 10}},
+		{"UPPERCASE", map[string]interface{}{"SAMPLERATE": 10}},
+		{"camelCase", map[string]interface{}{"sampleRate": 10}},
+		{"PascalCase", map[string]interface{}{"SampleRate": 10}},
+		{"MiXeDcAsE", map[string]interface{}{"SaMpLeRaTe": 10}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := getSampleRateKey(tt.attrs)
+			assert.Equal(t, "sampleRate", key)
+		})
+
+	}
 }
 
 func TestGetSampleRateConversions(t *testing.T) {
@@ -813,6 +816,12 @@ func TestGetSampleRateConversions(t *testing.T) {
 		{sampleRate: "0", expected: 1},
 		{sampleRate: "1", expected: 1},
 		{sampleRate: "100", expected: 100},
+		{sampleRate: "100.0", expected: 100},
+		{sampleRate: "100.4", expected: 100},
+		{sampleRate: "100.6", expected: 101},
+		{sampleRate: "-100", expected: 1},
+		{sampleRate: "-100.0", expected: 1},
+		{sampleRate: "-100.6", expected: 1},
 		{sampleRate: "invalid", expected: 1},
 		{sampleRate: strconv.Itoa(math.MaxInt32), expected: math.MaxInt32},
 		{sampleRate: strconv.Itoa(math.MaxInt64), expected: math.MaxInt32},
@@ -820,6 +829,12 @@ func TestGetSampleRateConversions(t *testing.T) {
 		{sampleRate: 0, expected: 1},
 		{sampleRate: 1, expected: 1},
 		{sampleRate: 100, expected: 100},
+		{sampleRate: 100.0, expected: 100},
+		{sampleRate: 100.4, expected: 100},
+		{sampleRate: 100.6, expected: 101},
+		{sampleRate: -100, expected: 1},
+		{sampleRate: -100.0, expected: 1},
+		{sampleRate: -100.6, expected: 1},
 		{sampleRate: math.MaxInt32, expected: math.MaxInt32},
 		{sampleRate: math.MaxInt64, expected: math.MaxInt32},
 

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -76,12 +76,16 @@ func TranslateLogsRequest(ctx context.Context, request *collectorLogs.ExportLogs
 					AddAttributesToMap(ctx, attrs, log.Attributes)
 				}
 
+				// get sample rate after resource and scope attributes have been added
+				sampleRate := GetSampleRate(attrs)
+
 				// Now we need to wrap the eventAttrs in an event so we can specify the timestamp
 				// which is the StartTime as a time.Time object
 				timestamp := time.Unix(0, int64(log.TimeUnixNano)).UTC()
 				events = append(events, Event{
 					Attributes: attrs,
 					Timestamp:  timestamp,
+					SampleRate: sampleRate,
 				})
 			}
 		}

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -77,7 +77,7 @@ func TranslateLogsRequest(ctx context.Context, request *collectorLogs.ExportLogs
 				}
 
 				// get sample rate after resource and scope attributes have been added
-				sampleRate := GetSampleRate(attrs)
+				sampleRate := getSampleRate(attrs)
 
 				// Now we need to wrap the eventAttrs in an event so we can specify the timestamp
 				// which is the StartTime as a time.Time object

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -75,6 +75,7 @@ func TestTranslateLogsRequest(t *testing.T) {
 			assert.Equal(t, "debug", ev.Attributes["severity"])
 			assert.Equal(t, testServiceName, ev.Attributes["service.name"])
 			assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
+			assert.Equal(t, int32(100), ev.SampleRate)
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 		})
 	}
@@ -146,6 +147,7 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 							assert.Equal(t, "debug", ev.Attributes["severity"])
 							assert.Equal(t, "my-service", ev.Attributes["service.name"])
 							assert.Equal(t, "span_attr_val", ev.Attributes["span_attr"])
+							assert.Equal(t, int32(100), ev.SampleRate)
 							assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 							assert.Equal(t, "instr_scope_name", ev.Attributes["library.name"])
 							assert.Equal(t, "instr_scope_version", ev.Attributes["library.version"])
@@ -547,6 +549,12 @@ func buildExportLogsServiceRequest(traceID []byte, spanID []byte, startTimestamp
 							Key: "span_attr",
 							Value: &common.AnyValue{
 								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
+							},
+						},
+						{
+							Key: "sampleRate",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_IntValue{IntValue: 100},
 							},
 						},
 					},

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -96,7 +96,7 @@ func TranslateTraceRequest(ctx context.Context, request *collectorTrace.ExportTr
 				}
 
 				// get sample rate after resource and scope attributes have been added
-				sampleRate := GetSampleRate(eventAttrs)
+				sampleRate := getSampleRate(eventAttrs)
 
 				// Now we need to wrap the eventAttrs in an event so we can specify the timestamp
 				// which is the StartTime as a time.Time object

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"io"
-	"math"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -749,71 +747,6 @@ func TestInvalidBodyReturnsError(t *testing.T) {
 	result, err := TranslateTraceRequestFromReader(context.Background(), body, ri)
 	assert.Nil(t, result)
 	assert.Equal(t, ErrFailedParseBody, err)
-}
-
-func TestNoSampleRateKeyReturnOne(t *testing.T) {
-	attrs := map[string]interface{}{
-		"not_a_sample_rate": 10,
-	}
-	sampleRate := getSampleRate(attrs)
-	assert.Equal(t, int32(1), sampleRate)
-}
-
-func TestCanDetectSampleRateCapitalizations(t *testing.T) {
-	t.Run("lowercase", func(t *testing.T) {
-		attrs := map[string]interface{}{
-			"sampleRate": 10,
-		}
-		key := getSampleRateKey(attrs)
-		assert.Equal(t, "sampleRate", key)
-	})
-	t.Run("uppercase", func(t *testing.T) {
-		attrs := map[string]interface{}{
-			"SampleRate": 10,
-		}
-		key := getSampleRateKey(attrs)
-		assert.Equal(t, "SampleRate", key)
-	})
-}
-
-func TestGetSampleRateConversions(t *testing.T) {
-	testCases := []struct {
-		sampleRate interface{}
-		expected   int32
-	}{
-		{sampleRate: nil, expected: 1},
-		{sampleRate: "0", expected: 1},
-		{sampleRate: "1", expected: 1},
-		{sampleRate: "100", expected: 100},
-		{sampleRate: "invalid", expected: 1},
-		{sampleRate: strconv.Itoa(math.MaxInt32), expected: math.MaxInt32},
-		{sampleRate: strconv.Itoa(math.MaxInt64), expected: math.MaxInt32},
-
-		{sampleRate: 0, expected: 1},
-		{sampleRate: 1, expected: 1},
-		{sampleRate: 100, expected: 100},
-		{sampleRate: math.MaxInt32, expected: math.MaxInt32},
-		{sampleRate: math.MaxInt64, expected: math.MaxInt32},
-
-		{sampleRate: int32(0), expected: 1},
-		{sampleRate: int32(1), expected: 1},
-		{sampleRate: int32(100), expected: 100},
-		{sampleRate: int32(math.MaxInt32), expected: math.MaxInt32},
-
-		{sampleRate: int64(0), expected: 1},
-		{sampleRate: int64(1), expected: 1},
-		{sampleRate: int64(100), expected: 100},
-		{sampleRate: int64(math.MaxInt32), expected: math.MaxInt32},
-		{sampleRate: int64(math.MaxInt64), expected: math.MaxInt32},
-	}
-
-	for _, tc := range testCases {
-		attrs := map[string]interface{}{
-			"sampleRate": tc.sampleRate,
-		}
-		assert.Equal(t, tc.expected, getSampleRate(attrs))
-		assert.Equal(t, 0, len(attrs))
-	}
 }
 
 func TestDefaultServiceNameApplied(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

- closes #274 

## Short description of the changes

- move sample rate logic that was in `traces` to `common`, including test cases
- add `sampleRate` to log events
- make `sampleRate` key name case-insensitive
- fall back to default rate of 1 when given negative values 
- round and coerce floats into ints

It would be nice to have an error if an invalid sampleRateKey is found. Right now we just return empty string.