### PR TITLE
chore: Remove SizeBytes from Batch struct

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -116,11 +116,9 @@ type TranslateOTLPRequestResult struct {
 }
 
 // Batch represents Honeycomb events grouped by their target dataset
-// SizeBytes is the total byte size of the OTLP structure that represents this batch
 type Batch struct {
-	Dataset   string
-	SizeBytes int
-	Events    []Event
+	Dataset string
+	Events  []Event
 }
 
 // Event represents a single Honeycomb event

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -87,7 +87,6 @@ func TranslateLogsRequest(ctx context.Context, request *collectorLogs.ExportLogs
 		}
 		batches = append(batches, Batch{
 			Dataset:   dataset,
-			SizeBytes: proto.Size(resourceLog),
 			Events:    events,
 		})
 	}

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -60,7 +60,6 @@ func TestTranslateLogsRequest(t *testing.T) {
 			assert.Equal(t, 1, len(result.Batches))
 			batch := result.Batches[0]
 			assert.Equal(t, tC.expectedDataset, batch.Dataset)
-			assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
 			events := batch.Events
 			assert.Equal(t, 1, len(events))
 
@@ -131,7 +130,6 @@ func TestTranslateHttpLogsRequest(t *testing.T) {
 							assert.Equal(t, 1, len(result.Batches))
 							batch := result.Batches[0]
 							assert.Equal(t, tC.expectedDataset, batch.Dataset)
-							assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
 							events := batch.Events
 							assert.Equal(t, 1, len(events))
 
@@ -489,7 +487,6 @@ func TestLogsWithoutTraceIdDoesNotGetAnnotationType(t *testing.T) {
 	assert.Equal(t, 1, len(result.Batches))
 	batch := result.Batches[0]
 	assert.Equal(t, "my-service", batch.Dataset)
-	assert.Equal(t, proto.Size(req.ResourceLogs[0]), batch.SizeBytes)
 	events := batch.Events
 	assert.Equal(t, 1, len(events))
 

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -208,9 +208,8 @@ func TranslateTraceRequest(ctx context.Context, request *collectorTrace.ExportTr
 			}
 		}
 		batches = append(batches, Batch{
-			Dataset:   dataset,
-			SizeBytes: proto.Size(resourceSpan),
-			Events:    events,
+			Dataset: dataset,
+			Events:  events,
 		})
 	}
 	return &TranslateOTLPRequestResult{

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -143,7 +143,6 @@ func TestTranslateGrpcTraceRequest(t *testing.T) {
 			assert.Equal(t, 1, len(result.Batches))
 			batch := result.Batches[0]
 			assert.Equal(t, tC.expectedDataset, batch.Dataset)
-			assert.Equal(t, proto.Size(req.ResourceSpans[0]), batch.SizeBytes)
 			events := batch.Events
 			assert.Equal(t, 3, len(events))
 
@@ -318,7 +317,6 @@ func TestTranslateException(t *testing.T) {
 			assert.Equal(t, 1, len(result.Batches))
 			batch := result.Batches[0]
 			assert.Equal(t, tC.expectedDataset, batch.Dataset)
-			assert.Equal(t, proto.Size(req.ResourceSpans[0]), batch.SizeBytes)
 			events := batch.Events
 			assert.Equal(t, 2, len(events))
 
@@ -412,8 +410,6 @@ func TestTranslateGrpcTraceRequestFromMultipleServices(t *testing.T) {
 	batchB := result.Batches[1]
 	assert.Equal(t, "my-service-a", batchA.Dataset)
 	assert.Equal(t, "my-service-b", batchB.Dataset)
-	assert.Equal(t, proto.Size(req.ResourceSpans[0]), batchA.SizeBytes)
-	assert.Equal(t, proto.Size(req.ResourceSpans[1]), batchB.SizeBytes)
 	eventsA := batchA.Events
 	eventsB := batchB.Events
 	assert.Equal(t, 1, len(eventsA))
@@ -605,7 +601,6 @@ func TestTranslateHttpTraceRequest(t *testing.T) {
 							assert.Equal(t, 1, len(result.Batches))
 							batch := result.Batches[0]
 							assert.Equal(t, tC.expectedDataset, batch.Dataset)
-							assert.Equal(t, proto.Size(req.ResourceSpans[0]), batch.SizeBytes)
 							events := batch.Events
 							assert.Equal(t, 3, len(events))
 
@@ -712,8 +707,6 @@ func TestTranslateHttpTraceRequestFromMultipleServices(t *testing.T) {
 	batchB := result.Batches[1]
 	assert.Equal(t, "my-service-a", batchA.Dataset)
 	assert.Equal(t, "my-service-b", batchB.Dataset)
-	assert.Equal(t, proto.Size(req.ResourceSpans[0]), batchA.SizeBytes)
-	assert.Equal(t, proto.Size(req.ResourceSpans[1]), batchB.SizeBytes)
 	eventsA := batchA.Events
 	eventsB := batchB.Events
 	assert.Equal(t, 1, len(eventsA))


### PR DESCRIPTION
## Which problem is this PR solving?

Removes the unused `Batch.SizeBytes` property.

## Short description of the changes
- remove unused batch.SizeBytes (we only use result.RequetSize)

