### PR TITLE
feat: add PHP to list of telemetry libraries

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -78,6 +78,7 @@ var (
 		"OpenTelemetry::Instrumentation",              // Ruby
 		"go.opentelemetry.io/contrib/instrumentation", // Go
 		"@opentelemetry/instrumentation",              // JS
+		"io.opentelemetry.contrib.php",                // PHP
 	}
 )
 

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -40,6 +40,7 @@ const (
 	gRPCAcceptEncodingHeader = "grpc-accept-encoding"
 	defaultServiceName       = "unknown_service"
 	unknownLogSource         = "unknown_log_source"
+	libraryNameKey           = "telemetry.instrumentation_library"
 
 	defaultSampleRate = int32(1)
 
@@ -306,7 +307,7 @@ func getScopeAttributes(ctx context.Context, scope *common.InstrumentationScope)
 		if scope.Name != "" {
 			attrs["library.name"] = scope.Name
 			if isInstrumentationLibrary(scope.Name) {
-				attrs["telemetry.instrumentation_library"] = true
+				attrs[libraryNameKey] = true
 			}
 		}
 		if scope.Version != "" {

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -40,7 +40,6 @@ const (
 	gRPCAcceptEncodingHeader = "grpc-accept-encoding"
 	defaultServiceName       = "unknown_service"
 	unknownLogSource         = "unknown_log_source"
-	libraryNameKey           = "telemetry.instrumentation_library"
 
 	defaultSampleRate = int32(1)
 
@@ -308,7 +307,7 @@ func getScopeAttributes(ctx context.Context, scope *common.InstrumentationScope)
 		if scope.Name != "" {
 			attrs["library.name"] = scope.Name
 			if isInstrumentationLibrary(scope.Name) {
-				attrs[libraryNameKey] = true
+				attrs["telemetry.instrumentation_library"] = true
 			}
 		}
 		if scope.Version != "" {

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1107,12 +1107,12 @@ func TestInstrumentationLibrarySpansHaveAttributeAdded(t *testing.T) {
 	assert.Equal(t, "test_span_a", first_event.Attributes["name"])
 	assert.Equal(t, "First", first_event.Attributes["library.name"])
 	assert.Equal(t, "1.1.1", first_event.Attributes["library.version"])
-	assert.NotContains(t, first_event.Attributes, "telemtetry.instrumentation_library")
+	assert.NotContains(t, first_event.Attributes, libraryNameKey)
 	second_event := events[1]
 	assert.Equal(t, "test_span_b", second_event.Attributes["name"])
 	assert.Equal(t, "io.opentelemetry.instrumentation.http", second_event.Attributes["library.name"])
 	assert.Equal(t, "2.2.2", second_event.Attributes["library.version"])
-	assert.Equal(t, true, second_event.Attributes["telemetry.instrumentation_library"])
+	assert.Equal(t, true, second_event.Attributes[libraryNameKey])
 }
 
 func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1107,7 +1107,7 @@ func TestInstrumentationLibrarySpansHaveAttributeAdded(t *testing.T) {
 	assert.Equal(t, "test_span_a", first_event.Attributes["name"])
 	assert.Equal(t, "First", first_event.Attributes["library.name"])
 	assert.Equal(t, "1.1.1", first_event.Attributes["library.version"])
-	assert.NotContains(t, first_event.Attributes, "telemtetry.instrumentation_library")
+	assert.NotContains(t, first_event.Attributes, "telemetry.instrumentation_library")
 	second_event := events[1]
 	assert.Equal(t, "test_span_b", second_event.Attributes["name"])
 	assert.Equal(t, "io.opentelemetry.instrumentation.http", second_event.Attributes["library.name"])

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1161,6 +1161,11 @@ func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {
 			libraryName:              "@opentelemetry/instrumentation/http",
 			isInstrumentationLibrary: true,
 		},
+		{
+			name:                     "php",
+			libraryName:              "io.opentelemetry.contrib.php.slim",
+			isInstrumentationLibrary: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1107,12 +1107,12 @@ func TestInstrumentationLibrarySpansHaveAttributeAdded(t *testing.T) {
 	assert.Equal(t, "test_span_a", first_event.Attributes["name"])
 	assert.Equal(t, "First", first_event.Attributes["library.name"])
 	assert.Equal(t, "1.1.1", first_event.Attributes["library.version"])
-	assert.NotContains(t, first_event.Attributes, libraryNameKey)
+	assert.NotContains(t, first_event.Attributes, "telemtetry.instrumentation_library")
 	second_event := events[1]
 	assert.Equal(t, "test_span_b", second_event.Attributes["name"])
 	assert.Equal(t, "io.opentelemetry.instrumentation.http", second_event.Attributes["library.name"])
 	assert.Equal(t, "2.2.2", second_event.Attributes["library.version"])
-	assert.Equal(t, true, second_event.Attributes[libraryNameKey])
+	assert.Equal(t, true, second_event.Attributes["telemetry.instrumentation_library"])
 }
 
 func TestKnownInstrumentationPrefixesReturnTrue(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

- lack of visibility into php library usage

## Short description of the changes

- add PHP instrumentation library prefix 
- fix typo in test for `telemetry.instrumentation_name`
