### PR TITLE
maint: prepare for release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Husky Changelog
 
+## 0.31.0 2024-10-18
+
+- feat: add PHP to list of telemetry libraries (#278) | [Jamie Danielson](https://github.com/JamieDanielson)
+- feat: add sample rate to logs if set (#275) | [Jamie Danielson](https://github.com/JamieDanielson)
+- chore: Remove SizeBytes from Batch struct (#276) | [Mike Goldsmith](https://github.com/MikeGoldsmith)
+- docs: update vulnerability reporting process (#269) | [Robb Kidd](https://github.com/robbkidd)
+- maint: appease codeql warning (#270) | [Alex Boten](https://github.com/codeboten)
+- maint(deps): bump google.golang.org/grpc from 1.64.0 to 1.64.1 (#271) | @dependabot
+- maint(deps): bump the minor-patch group with 2 updates (#268) | @dependabot
+
 ## 0.30.0 2024-06-05
 
 - fix: Ensure a limited reader is used when decompressing payloads (#265) | @codeboten

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - chore: Remove SizeBytes from Batch struct (#276) | [Mike Goldsmith](https://github.com/MikeGoldsmith)
 - docs: update vulnerability reporting process (#269) | [Robb Kidd](https://github.com/robbkidd)
 - maint: appease codeql warning (#270) | [Alex Boten](https://github.com/codeboten)
+- maint(deps): bump the minor-patch group across 1 directory with 2 updates (#279) | @dependabot
 - maint(deps): bump google.golang.org/grpc from 1.64.0 to 1.64.1 (#271) | @dependabot
 - maint(deps): bump the minor-patch group with 2 updates (#268) | @dependabot
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package husky
 
 var (
-	Version string = "0.30.0"
+	Version string = "0.31.0"
 )


### PR DESCRIPTION
## Which problem is this PR solving?

- prepare for v0.31.0 release

## Short description of the changes

- update version.go
- update CHANGELOG.md entries

