### PR TITLE
fix: Return the actual key from getSampleRateKey

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -642,7 +642,7 @@ func getSampleRate(attrs map[string]interface{}) int32 {
 func getSampleRateKey(attrs map[string]interface{}) string {
 	for key := range attrs {
 		if strings.EqualFold(key, "sampleRate") {
-			return "sampleRate"
+			return key
 		}
 	}
 	return ""

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -791,17 +791,19 @@ func TestCanDetectSampleRateCapitalizations(t *testing.T) {
 	tests := []struct {
 		name  string
 		attrs map[string]interface{}
+		want  string
 	}{
-		{"lowercase", map[string]interface{}{"samplerate": 10}},
-		{"UPPERCASE", map[string]interface{}{"SAMPLERATE": 10}},
-		{"camelCase", map[string]interface{}{"sampleRate": 10}},
-		{"PascalCase", map[string]interface{}{"SampleRate": 10}},
-		{"MiXeDcAsE", map[string]interface{}{"SaMpLeRaTe": 10}},
+		{"lowercase", map[string]interface{}{"samplerate": 10}, "samplerate"},
+		{"UPPERCASE", map[string]interface{}{"SAMPLERATE": 10}, "SAMPLERATE"},
+		{"camelCase", map[string]interface{}{"sampleRate": 10}, "sampleRate"},
+		{"PascalCase", map[string]interface{}{"SampleRate": 10}, "SampleRate"},
+		{"MiXeDcAsE", map[string]interface{}{"SaMpLeRaTe": 10}, "SaMpLeRaTe"},
+		{"bad", map[string]interface{}{"sample_rate": 10}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			key := getSampleRateKey(tt.attrs)
-			assert.Equal(t, "sampleRate", key)
+			assert.Equal(t, tt.want, key)
 		})
 
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- We had a function that was supposed to return the sampleRate key being used, but instead it always returned `sampleRate`, which broke things that didn't use that exact case.

## Short description of the changes

- Return the actual key in use
- Adjust the test to use it

