### PR TITLE
fix: revert back to recognize only "sampleRate" or "SampleRate" attributes

### DIFF
--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -787,18 +787,20 @@ func TestNoSampleRateKeyReturnOne(t *testing.T) {
 	assert.Equal(t, int32(1), sampleRate)
 }
 
-func TestCanDetectSampleRateCapitalizations(t *testing.T) {
+func TestSampleRateKeyVariations(t *testing.T) {
 	tests := []struct {
 		name  string
 		attrs map[string]interface{}
 		want  string
 	}{
-		{"lowercase", map[string]interface{}{"samplerate": 10}, "samplerate"},
-		{"UPPERCASE", map[string]interface{}{"SAMPLERATE": 10}, "SAMPLERATE"},
-		{"camelCase", map[string]interface{}{"sampleRate": 10}, "sampleRate"},
-		{"PascalCase", map[string]interface{}{"SampleRate": 10}, "SampleRate"},
-		{"MiXeDcAsE", map[string]interface{}{"SaMpLeRaTe": 10}, "SaMpLeRaTe"},
-		{"bad", map[string]interface{}{"sample_rate": 10}, ""},
+		// ACCEPTED - only accept the two variations we've done in the past
+		{"ACCEPTED/camelCase", map[string]interface{}{"sampleRate": 10}, "sampleRate"},
+		{"ACCEPTED/PascalCase", map[string]interface{}{"SampleRate": 10}, "SampleRate"},
+		// IGNORED - other variations will be ignored
+		{"INGORED/lowercase", map[string]interface{}{"samplerate": 10}, ""},
+		{"INGORED/UPPERCASE", map[string]interface{}{"SAMPLERATE": 10}, ""},
+		{"INGORED/MiXeDcAsE", map[string]interface{}{"SaMpLeRaTe": 10}, ""},
+		{"INGORED/snake_case", map[string]interface{}{"sample_rate": 10}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

1. A predicted performance regression during ingest: iterating over all attributes looking for a matching key name is much slower than 2 lookups into the attributes map.
2. Non-deterministic behavior in the probably-rare case of attributes containing multiple "samplerate" keys of differing capitalization, which would be astonishingly difficult to troubleshoot after ingest

## Short description of the changes

- update the test to assert the previous behavior of recognizing only `sampleRate` and `SampleRate`
- … more coming

