### PR TITLE
rel: prepare v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Husky Changelog
 
+## 0.33.0 2024-11-14
+
+- fix: revert back to recognize only "sampleRate" or "SampleRate" attributes (#284) | [Robb Kidd](https://github.com/robbkidd)
+
 ## 0.32.0 2024-11-13
 
 - fix: Return the actual key from getSampleRateKey (#282) | [Kent Quirk](https://github.com/kentquirk)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package husky
 
 var (
-	Version string = "0.32.0"
+	Version string = "0.33.0"
 )


### PR DESCRIPTION
## Which problem is this PR solving?

- release the revert back to "(s|S)ampleRate only" behavior (#284)

## Short description of the changes

- version bumped
- changelog updated

