### PR TITLE
fix: Disable HTML escaping when JSON encoding values

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -460,9 +460,10 @@ func addAttributeToMap(ctx context.Context, result map[string]interface{}, key s
 // addAttributeToMapAsJson adds an attribute to a map as a JSON string.
 // Uses limitedWriter to ensure that the string can't be bigger than the maximum field size and
 // helps reduce allocation and copying.
-// Note that an Encoder emits JSON with a trailing newline because it's intended for use
+// Notes:
+// - The Encoder emits JSON with a trailing newline because it's intended for use
 // in streaming. This is correct but sometimes surprising and the tests need to expect it.
-// NOTE: The JSON encoder has HTML escaping disabled.
+// - The encoder has HTML escaping disabled.
 func addAttributeToMapAsJson(attrs map[string]interface{}, key string, value *common.AnyValue) int {
 	val := getMarshallableValue(value)
 	w := newLimitedWriter(fieldSizeMax)

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -462,10 +462,13 @@ func addAttributeToMap(ctx context.Context, result map[string]interface{}, key s
 // helps reduce allocation and copying.
 // Note that an Encoder emits JSON with a trailing newline because it's intended for use
 // in streaming. This is correct but sometimes surprising and the tests need to expect it.
+// NOTE: The JSON encoder has HTML escaping disabled.
 func addAttributeToMapAsJson(attrs map[string]interface{}, key string, value *common.AnyValue) int {
 	val := getMarshallableValue(value)
 	w := newLimitedWriter(fieldSizeMax)
-	if err := json.NewEncoder(w).Encode(val); err != nil {
+	e := json.NewEncoder(w)
+	e.SetEscapeHTML(false)
+	if err := e.Encode(val); err != nil {
 		// TODO: log error or report error when we have a way to do so
 		return 0
 	}

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -862,3 +862,11 @@ func TestGetSampleRateConversions(t *testing.T) {
 		assert.Equal(t, 0, len(attrs))
 	}
 }
+
+func TestAddAttributesToMapAreNotHTMLEncoded(t *testing.T) {
+	key := "my-html"
+	val := "<html><body><h1>hello</h1></body></html>"
+	attrs := map[string]interface{}{}
+	addAttributeToMapAsJson(attrs, key, &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: val}})
+	assert.Equal(t, "\"<html><body><h1>hello</h1></body></html>\"\n", attrs[key])
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Husky JSON encodes attribute values in certain circumstances (eg deeply nested attributes). However, by default the JSON encoder escapes HTML characters which makes using the values more difficult later.

This change updates the JSON encoder to not escape HTML characters.

## Short description of the changes
- Disable HTML escaping in the JSON encoder by calling `SetEscapeHTML(false)`
- Add unit test to verify an attribute that contains HTML is not escaped

