### PR TITLE
feat: Allow OTLP/HTTP request translation to be provided max request body size

### DIFF
--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -465,19 +465,14 @@ func TestTranslateLogsRequestFromReaderSized(t *testing.T) {
 		ContentType: "application/protobuf",
 	}
 
+	result, err := TranslateLogsRequestFromReaderSized(context.Background(), bodyValid, ri, int64(len(bodyBytes)*2))
+	assert.Nil(t, err)
+	assert.Equal(t, proto.Size(req), result.RequestSize)
+
 	bufTooLarge := new(bytes.Buffer)
 	bufTooLarge.Write(bodyBytes)
 
 	bodyTooLarge := io.NopCloser(strings.NewReader(bufTooLarge.String()))
-	ri = RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "legacy-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	result, err := TranslateLogsRequestFromReaderSized(context.Background(), bodyValid, ri, int64(len(bodyBytes)*2))
-	assert.Nil(t, err)
-	assert.Equal(t, proto.Size(req), result.RequestSize)
 
 	_, err = TranslateLogsRequestFromReaderSized(context.Background(), bodyTooLarge, ri, int64(len(bodyBytes)/10))
 	assert.NotNil(t, err)

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -430,6 +430,60 @@ func TestCanExtractBody(t *testing.T) {
 	}
 }
 
+func TestTranslateLogsRequestFromReaderSized(t *testing.T) {
+	startTimestamp := time.Now()
+	req := &collectorlogs.ExportLogsServiceRequest{
+		ResourceLogs: []*logs.ResourceLogs{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service"},
+					},
+				}},
+			},
+			ScopeLogs: []*logs.ScopeLogs{{
+				LogRecords: []*logs.LogRecord{{
+					TimeUnixNano:   uint64(startTimestamp.Nanosecond()),
+					SeverityText:   "test_severity_text",
+					SeverityNumber: logs.SeverityNumber_SEVERITY_NUMBER_DEBUG,
+				}},
+			}},
+		}},
+	}
+
+	bodyBytes, err := proto.Marshal(req)
+	assert.Nil(t, err)
+
+	bufValid := new(bytes.Buffer)
+	bufValid.Write(bodyBytes)
+
+	bodyValid := io.NopCloser(strings.NewReader(bufValid.String()))
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	bufTooLarge := new(bytes.Buffer)
+	bufTooLarge.Write(bodyBytes)
+
+	bodyTooLarge := io.NopCloser(strings.NewReader(bufTooLarge.String()))
+	ri = RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := TranslateLogsRequestFromReaderSized(context.Background(), bodyValid, ri, int64(len(bodyBytes)*2))
+	assert.Nil(t, err)
+	assert.Equal(t, proto.Size(req), result.RequestSize)
+
+	_, err = TranslateLogsRequestFromReaderSized(context.Background(), bodyTooLarge, ri, int64(len(bodyBytes)/10))
+	assert.NotNil(t, err)
+	assert.Equal(t, ErrFailedParseBody, err)
+}
+
 func TestLogsRequestWithInvalidContentTypeReturnsError(t *testing.T) {
 	req := &collectorlogs.ExportLogsServiceRequest{}
 	ri := RequestInfo{

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -21,11 +21,18 @@ const (
 // TranslateTraceRequestFromReader translates an OTLP/HTTP request into Honeycomb-friendly structure
 // RequestInfo is the parsed information from the HTTP headers
 func TranslateTraceRequestFromReader(ctx context.Context, body io.ReadCloser, ri RequestInfo) (*TranslateOTLPRequestResult, error) {
+	return TranslateTraceRequestFromReaderSized(ctx, body, ri, defaultMaxRequestBodySize)
+}
+
+// TranslateTraceRequestFromReaderSized translates an OTLP/HTTP request into Honeycomb-friendly structure
+// RequestInfo is the parsed information from the HTTP headers
+// maxSize is the maximum size of the request body in bytes
+func TranslateTraceRequestFromReaderSized(ctx context.Context, body io.ReadCloser, ri RequestInfo, maxSize int64) (*TranslateOTLPRequestResult, error) {
 	if err := ri.ValidateTracesHeaders(); err != nil {
 		return nil, err
 	}
 	request := &collectorTrace.ExportTraceServiceRequest{}
-	if err := parseOtlpRequestBody(body, ri.ContentType, ri.ContentEncoding, request, defaultMaxRequestBodySize); err != nil {
+	if err := parseOtlpRequestBody(body, ri.ContentType, ri.ContentEncoding, request, maxSize); err != nil {
 		return nil, ErrFailedParseBody
 	}
 	return TranslateTraceRequest(ctx, request, ri)

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -764,19 +764,14 @@ func TestTranslateTraceRequestFromReaderSized(t *testing.T) {
 		ContentType: "application/protobuf",
 	}
 
+	result, err := TranslateTraceRequestFromReaderSized(context.Background(), bodyValid, ri, int64(len(bodyBytes)*2))
+	assert.Nil(t, err)
+	assert.Equal(t, proto.Size(req), result.RequestSize)
+
 	bufTooLarge := new(bytes.Buffer)
 	bufTooLarge.Write(bodyBytes)
 
 	bodyTooLarge := io.NopCloser(strings.NewReader(bufTooLarge.String()))
-	ri = RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "legacy-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	result, err := TranslateTraceRequestFromReaderSized(context.Background(), bodyValid, ri, int64(len(bodyBytes)*2))
-	assert.Nil(t, err)
-	assert.Equal(t, proto.Size(req), result.RequestSize)
 
 	_, err = TranslateTraceRequestFromReaderSized(context.Background(), bodyTooLarge, ri, int64(len(bodyBytes)/10))
 	assert.NotNil(t, err)

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -714,6 +714,75 @@ func TestTranslateHttpTraceRequestFromMultipleServices(t *testing.T) {
 	assert.Equal(t, "test_span_b", eventsB[0].Attributes["name"])
 }
 
+func TestTranslateTraceRequestFromReaderSized(t *testing.T) {
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service-a"},
+					},
+				}},
+			},
+			ScopeSpans: []*trace.ScopeSpans{{
+				Spans: []*trace.Span{{
+					TraceId: test.RandomBytes(16),
+					SpanId:  test.RandomBytes(8),
+					Name:    "test_span_a",
+				}},
+			}},
+		}, {
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{{
+					Key: "service.name",
+					Value: &common.AnyValue{
+						Value: &common.AnyValue_StringValue{StringValue: "my-service-b"},
+					},
+				}},
+			},
+			ScopeSpans: []*trace.ScopeSpans{{
+				Spans: []*trace.Span{{
+					TraceId: test.RandomBytes(16),
+					SpanId:  test.RandomBytes(8),
+					Name:    "test_span_b",
+				}},
+			}},
+		}},
+	}
+
+	bodyBytes, err := proto.Marshal(req)
+	assert.Nil(t, err)
+
+	bufValid := new(bytes.Buffer)
+	bufValid.Write(bodyBytes)
+
+	bodyValid := io.NopCloser(strings.NewReader(bufValid.String()))
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	bufTooLarge := new(bytes.Buffer)
+	bufTooLarge.Write(bodyBytes)
+
+	bodyTooLarge := io.NopCloser(strings.NewReader(bufTooLarge.String()))
+	ri = RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "legacy-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := TranslateTraceRequestFromReaderSized(context.Background(), bodyValid, ri, int64(len(bodyBytes)*2))
+	assert.Nil(t, err)
+	assert.Equal(t, proto.Size(req), result.RequestSize)
+
+	_, err = TranslateTraceRequestFromReaderSized(context.Background(), bodyTooLarge, ri, int64(len(bodyBytes)/10))
+	assert.NotNil(t, err)
+	assert.Equal(t, ErrFailedParseBody, err)
+}
+
 func TestInvalidContentTypeReturnsError(t *testing.T) {
 	bodyBytes, _ := proto.Marshal(&collectortrace.ExportTraceServiceRequest{})
 	body := io.NopCloser(bytes.NewReader(bodyBytes))


### PR DESCRIPTION
## Which problem is this PR solving?

When passing Husky Traces or Logs OTLP/HTTP request bodies, Husky currently defaults to a max request body size of 20MiB when the body is parsed. This can cause parsing issues if Husky is passed a file larger than 20MiB that contains batched trace or log telemetry within a single file. OTel collector batch processor configurations can reasonably exceed this limit for single files.

This PR creates some flexibility for the caller to define that limit while still [guarding against zipbombs](https://github.com/honeycombio/husky/pull/265) and maintaining existing functionality.

## Short description of the changes

- Adds two new functions, `TranslateTraceRequestFromReaderSized` and `TranslateLogsRequestFromReaderSized` that allows a maxSize argument to be passed in
- Wraps `TranslateTraceRequestFromReader` and `TranslateLogsRequestFromReader` around these new functions, passing in the Husky-defined max request body size limit of 20 MiB

The end result should be a no-op. All current callers of `TranslateTraceRequestFromReader` and `TranslateLogsRequestFromReader` will continue to have their request bodies limited to 20 MiB. The new functions will be opt-in.