### PR TITLE
maint: prepare for release v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Husky Changelog
 
+## 0.35.0 2025-05-01
+
+- feat: Allow OTLP/HTTP request translation to be provided max request body size (#297) | [Josh Parsons](https://github.com/JoshParsons)
+- maint(deps): bump the minor-patch group across 1 directory with 3 updates (#295) | [dependabot[bot]](https://github.com/dependabot[bot])
+- maint(deps): bump golang.org/x/net from 0.30.0 to 0.33.0 (#291) | [dependabot[bot]](https://github.com/dependabot[bot])
+- maint(deps): bump the minor-patch group with 2 updates (#290) | [dependabot[bot]](https://github.com/dependabot[bot])
+
 ## 0.34.0 2024-12-11
 
 - fix: Disable HTML escaping when JSON encoding values (#288) | @MikeGoldsmith

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package husky
 
 var (
-	Version string = "0.34.0"
+	Version string = "0.35.0"
 )


### PR DESCRIPTION
## Which problem is this PR solving?

- Prepares the v0.35.0 release.
 
## Short description of the changes

- Update version to 0.35.0
- Add change log entry

