### PR TITLE
feat: Add the JS honeycomb prefix

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -81,6 +81,7 @@ var (
 		"go.opentelemetry.io/contrib/instrumentation", // Go
 		"@opentelemetry/instrumentation",              // JS
 		"io.opentelemetry.contrib.php",                // PHP
+		"@honeycombio/",                               // Honeycomb's own JS instrumentation libraries
 	}
 )
 


### PR DESCRIPTION
## Which problem is this PR solving?

We don't know if people are using the JS honeycomb auto instrumentation libraries.

## Short description of the changes

Adds the prefix that we use to denote our auto instrumentation libraries in https://github.com/honeycombio/honeycomb-opentelemetry-web so that we can capture this information.