### PR TITLE
feat: alternative optimized proto -> messagepack path for traces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.128.0
 	github.com/stretchr/testify v1.10.0
+	github.com/tinylib/msgp v1.3.0
+	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9
 	google.golang.org/grpc v1.72.2
@@ -16,15 +18,18 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.34.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.128.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tinylib/msgp v1.3.0
-	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9
 	google.golang.org/grpc v1.72.2
@@ -18,7 +17,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -29,7 +27,6 @@ require (
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
 github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -37,6 +38,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.128.0 h1:fiDLn93mLWMj+Al+9zqPZau7XotRUY0T21piYzvTjtk=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.128.0/go.mod h1:FdjIve3H9ZdXBuXy1JLCRjCeXtuOG4VP08+SQHv1DYs=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
@@ -45,6 +48,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tinylib/msgp v1.3.0 h1:ULuf7GPooDaIlbyvgAxBV/FI7ynli6LZ1/nVUNu+0ww=
+github.com/tinylib/msgp v1.3.0/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
+github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
+github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
@@ -71,6 +78,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -85,6 +93,7 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
 golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
@@ -96,6 +105,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
+google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de h1:F6qOa9AZTYJXOUEr4jDysRDLrm4PHePlge4v4TGAlxY=
 google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de/go.mod h1:VUhTRKeHn9wwcdrk73nvdC9gF178Tzhmt/qyaFcPLSo=
 google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a h1:nwKuGPlUAt+aR+pcrkfFRrTU1BVrSmYyYMxYbUIVHr0=

--- a/go.sum
+++ b/go.sum
@@ -9,7 +9,6 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
 github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
-github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -50,8 +49,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tinylib/msgp v1.3.0 h1:ULuf7GPooDaIlbyvgAxBV/FI7ynli6LZ1/nVUNu+0ww=
 github.com/tinylib/msgp v1.3.0/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
-github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
-github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
@@ -78,7 +75,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -93,7 +89,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
 golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
@@ -105,8 +100,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
-google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de h1:F6qOa9AZTYJXOUEr4jDysRDLrm4PHePlge4v4TGAlxY=
 google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de/go.mod h1:VUhTRKeHn9wwcdrk73nvdC9gF178Tzhmt/qyaFcPLSo=
 google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a h1:nwKuGPlUAt+aR+pcrkfFRrTU1BVrSmYyYMxYbUIVHr0=

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -580,7 +580,10 @@ func BytesToSpanID(spanID []byte) string {
 }
 
 func shouldTrimTraceId(traceID []byte) bool {
-	for i := 0; i < 8; i++ {
+	if len(traceID) != traceIDLongLength {
+		return false
+	}
+	for i := 0; i < traceIDShortLength; i++ {
 		if traceID[i] != 0 {
 			return false
 		}

--- a/otlp/common.go
+++ b/otlp/common.go
@@ -445,12 +445,14 @@ func addAttributeToMap(ctx context.Context, result map[string]interface{}, key s
 			"received_kvlist_attr_type": true,
 			"kvlist_max_depth":          depth,
 		})
-		for _, entry := range value.GetKvlistValue().Values {
-			k := key + "." + entry.Key
-			if depth < maxDepth {
+		if depth >= maxDepth {
+			// If we've reached max depth, encode the entire kvlist as JSON
+			addAttributeToMapAsJson(result, key, value)
+		} else {
+			// Otherwise, continue flattening
+			for _, entry := range value.GetKvlistValue().Values {
+				k := key + "." + entry.Key
 				addAttributeToMap(ctx, result, k, entry.Value, depth+1)
-			} else {
-				addAttributeToMapAsJson(result, k, entry.Value)
 			}
 		}
 	}

--- a/otlp/common_testhelpers.go
+++ b/otlp/common_testhelpers.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
-	"github.com/vmihailenco/msgpack"
+	"github.com/tinylib/msgp/msgp"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -90,11 +90,11 @@ func testCaseNameForEncoding(encoding string) string {
 
 // decodeMessagePackAttributes unmarshals MessagePack data into a map for testing
 func decodeMessagePackAttributes(t testing.TB, data []byte) map[string]any {
-	decoder := msgpack.NewDecoder(bytes.NewReader(data))
-	decoder.UseDecodeInterfaceLoose(true)
-
-	var attrs map[string]any
-	err := decoder.Decode(&attrs)
-	require.NoError(t, err, "Failed to unmarshal MessagePack attributes")
-	return attrs
+	decoded, _, err := msgp.ReadIntfBytes(data)
+	require.NoError(t, err)
+	if asMap, ok := decoded.(map[string]any); ok {
+		return asMap
+	}
+	t.Fatal("this doesn't look like a msgp map")
+	return nil
 }

--- a/otlp/common_testhelpers.go
+++ b/otlp/common_testhelpers.go
@@ -5,8 +5,11 @@ import (
 	"compress/gzip"
 	"errors"
 	"strings"
+	"testing"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -83,4 +86,15 @@ func testCaseNameForEncoding(encoding string) string {
 	} else {
 		return encoding
 	}
+}
+
+// decodeMessagePackAttributes unmarshals MessagePack data into a map for testing
+func decodeMessagePackAttributes(t testing.TB, data []byte) map[string]any {
+	decoder := msgpack.NewDecoder(bytes.NewReader(data))
+	decoder.UseDecodeInterfaceLoose(true)
+
+	var attrs map[string]any
+	err := decoder.Decode(&attrs)
+	require.NoError(t, err, "Failed to unmarshal MessagePack attributes")
+	return attrs
 }

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -55,13 +55,10 @@ var zstdDecoderPool = sync.Pool{
 	},
 }
 
-// TranslateTraceRequestFromReaderSizedWithMsgp translates an OTLP/HTTP
-// request into the Honeycomb-friendly structure using direct unmarshaling
-// to avoid creating intermediate proto structs.
+// TranslateTraceRequestFromReaderSizedWithMsgp translates an OTLP/HTTP request
+// directly into our Honeycomb-friendly structure, avoiding intermediate proto
+// structs.
 // Note the returned data is shiny new heap memory and is safe for callers to keep.
-// This is a performance optimization that processes the serialized data directly.
-// RequestInfo is the parsed information from the HTTP headers.
-// maxSize is the maximum size of the request body in bytes.
 func TranslateTraceRequestFromReaderSizedWithMsgp(
 	ctx context.Context,
 	body io.ReadCloser,
@@ -116,13 +113,11 @@ func TranslateTraceRequestFromReaderSizedWithMsgp(
 		httpBodyBufferPool.Put(bodyBuffer)
 	}()
 
-	// Read the decompressed data
 	_, err := bodyBuffer.ReadFrom(reader)
 	if err != nil {
 		return nil, ErrFailedParseBody
 	}
 
-	// Call the msgpack version
 	return unmarshalTraceRequestDirectMsgp(ctx, bodyBuffer.Bytes(), ri)
 }
 

--- a/otlp/traces_direct.go
+++ b/otlp/traces_direct.go
@@ -1,0 +1,1340 @@
+package otlp
+
+// OTLP Trace Message Hierarchy and Honeycomb Translation:
+//
+// ExportTraceServiceRequest
+// └── ResourceSpans (repeated) -> Each ResourceSpans creates events grouped by dataset
+//     ├── Resource
+//     │   └── attributes: KeyValue (repeated) -> Copied to all events from this resource
+//     │                                          Special: "service.name" determines dataset for non-classic keys
+//     ├── ScopeSpans (repeated)
+//     │   ├── InstrumentationScope
+//     │   │   ├── name: string -> "library.name", sets "telemetry.instrumentation_library"=true if recognized
+//     │   │   ├── version: string -> "library.version"
+//     │   │   └── attributes: KeyValue (repeated) -> Merged into all spans from this scope
+//     │   └── Span (repeated) -> Each span becomes an event, plus events for span events/links
+//     │       ├── trace_id: bytes -> "trace.trace_id" (hex encoded)
+//     │       ├── span_id: bytes -> "trace.span_id" (hex encoded)
+//     │       ├── parent_span_id: bytes -> "trace.parent_id" (hex encoded, if present)
+//     │       ├── name: string -> "name"
+//     │       ├── kind: Span.SpanKind (enum) -> "span.kind" and "type" (string: client/server/producer/consumer/internal)
+//     │       ├── start_time_unix_nano: fixed64 -> Event.Timestamp
+//     │       ├── end_time_unix_nano: fixed64 -> Used to calculate "duration_ms" = (end - start) / 1e6
+//     │       ├── attributes: KeyValue (repeated) -> Merged into span event
+//     │       │                                      Special: "sampleRate" determines Event.SampleRate
+//     │       ├── events: Span.Event (repeated) -> Each becomes a separate event
+//     │       │   ├── time_unix_nano: fixed64 -> Event.Timestamp
+//     │       │   ├── name: string -> "name"
+//     │       │   └── attributes: KeyValue (repeated) -> Merged with resource/scope attrs
+//     │       │                                          Additional fields:
+//     │       │                                          - "trace.trace_id" (from parent span)
+//     │       │                                          - "trace.parent_id" (parent span's span_id)
+//     │       │                                          - "parent_name" (parent span's name)
+//     │       │                                          - "meta.annotation_type" = "span_event"
+//     │       │                                          - "meta.signal_type" = "trace"
+//     │       │                                          - "meta.time_since_span_start_ms" = (event_time - span_start) / 1e6
+//     │       │                                          - "error" = true (if parent span has error status)
+//     │       │                                          Exception events: attrs copied to parent span if name="exception"
+//     │       ├── links: Span.Link (repeated) -> Each becomes a separate event
+//     │       │   ├── trace_id: bytes -> "trace.link.trace_id" (hex encoded)
+//     │       │   ├── span_id: bytes -> "trace.link.span_id" (hex encoded)
+//     │       │   ├── trace_state: string -> (merged into attributes)
+//     │       │   └── attributes: KeyValue (repeated) -> Merged with resource/scope attrs
+//     │       │                                          Additional fields:
+//     │       │                                          - "trace.trace_id" (from parent span)
+//     │       │                                          - "trace.parent_id" (parent span's span_id)
+//     │       │                                          - "parent_name" (parent span's name)
+//     │       │                                          - "meta.annotation_type" = "link"
+//     │       │                                          - "meta.signal_type" = "trace"
+//     │       │                                          - "error" = true (if parent span has error status)
+//     │       ├── status: Status
+//     │       │   ├── code: Status.StatusCode (enum) -> "status_code" (int), "status.code" (string)
+//     │       │   │                                     Sets "error"=true if code=2 (ERROR)
+//     │       │   └── message: string -> "status_message" and "status.message"
+//     │       └── trace_state: string -> "trace.trace_state", used for sampleRate calculation
+//     └── schema_url: string -> (ignored)
+//
+// Additional span event attributes:
+// - "span.num_events": Count of span events
+// - "span.num_links": Count of span links
+// - "meta.signal_type": Always "trace"
+// - "meta.invalid_duration": true if duration < 0
+// - "meta.invalid_time_since_span_start": true if span event time < span start time
+//
+// Common types:
+// - KeyValue: { key: string, value: AnyValue }
+// - AnyValue: oneof { string_value, bool_value, int_value, double_value, array_value, kvlist_value, bytes_value }
+//             (array_value and bytes_value are JSON-encoded, kvlist_value is flattened with dot notation)
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math"
+	"time"
+
+	"github.com/honeycombio/husky"
+)
+
+var (
+	ErrInvalidLength        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflow          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroup = fmt.Errorf("proto: unexpected end of group")
+)
+
+// UnmarshalTraceRequestDirect translates a serialized OTLP trace request directly
+// into Honeycomb-friendly structure without creating intermediate proto structs.
+// This is a performance optimization that avoids the overhead of unmarshaling
+// into proto structs first.
+// Why does the code look like this? Because it's derived from gogo's generated
+// code, and carries over some of the style conventions so that it will hopefully
+// be relatively easy to update it in future, should that be necessary.
+// Fortunately this part of OTLP is marked as "stable" so we don't expect changes.
+func UnmarshalTraceRequestDirect(ctx context.Context, data []byte, ri RequestInfo) (*TranslateOTLPRequestResult, error) {
+	if err := ri.ValidateTracesHeaders(); err != nil {
+		return nil, err
+	}
+
+	result := &TranslateOTLPRequestResult{
+		RequestSize: len(data),
+		Batches:     []Batch{},
+	}
+
+	// Parse the protobuf wire format
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return nil, err
+		}
+		if wireType == 4 {
+			return nil, fmt.Errorf("proto: ExportTraceServiceRequest: wiretype end group for non-group")
+		}
+
+		switch fieldNum {
+		case 1: // ResourceSpans
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return nil, err
+			}
+
+			// Parse the ResourceSpans
+			err = unmarshalResourceSpans(ctx, slice, ri, result)
+			if err != nil {
+				return nil, err
+			}
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if iNdEx > l {
+		return nil, io.ErrUnexpectedEOF
+	}
+
+	return result, nil
+}
+
+// unmarshalResourceSpans parses a ResourceSpans message
+func unmarshalResourceSpans(ctx context.Context, data []byte, ri RequestInfo, result *TranslateOTLPRequestResult) error {
+	resourceAttrs := make(map[string]any)
+	dataset := ""
+	var scopeSpansData [][]byte
+
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return err
+		}
+
+		switch fieldNum {
+		case 1: // resource
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+			// Parse resource
+			err = unmarshalResource(ctx, slice, resourceAttrs)
+			if err != nil {
+				return err
+			}
+
+		case 2: // scope_spans
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+			// Collect ScopeSpans data to process later
+			scopeSpansData = append(scopeSpansData, slice)
+
+		case 3: // schema_url
+			_, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			// Skip the string value
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Determine dataset from resource attributes
+	dataset = getDataset(ri, resourceAttrs)
+
+	// Now process the collected ScopeSpans with the determined dataset
+	for _, scopeSpansBytes := range scopeSpansData {
+		err := unmarshalScopeSpans(ctx, scopeSpansBytes, ri, resourceAttrs, dataset, result)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// unmarshalResource parses a Resource message
+func unmarshalResource(ctx context.Context, data []byte, attrs map[string]any) error {
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return err
+		}
+
+		switch fieldNum {
+		case 1: // attributes
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+			// Parse KeyValue
+			err = unmarshalKeyValue(ctx, slice, attrs, 0)
+			if err != nil {
+				return err
+			}
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// unmarshalKeyValue parses a KeyValue message
+func unmarshalKeyValue(ctx context.Context, data []byte, attrs map[string]any, depth int) error {
+	var key string
+	var value any
+
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return err
+		}
+
+		switch fieldNum {
+		case 1: // key
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			key = string(slice)
+
+		case 2: // value
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+			// Parse AnyValue
+			val, err := unmarshalAnyValue(ctx, slice)
+			if err != nil {
+				return err
+			}
+			value = val
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return err
+			}
+		}
+	}
+
+	// KeyValue messages should have both key and value
+	if key != "" && value != nil {
+		// Handle different value types to match legacy behavior
+		switch v := value.(type) {
+		case []byte:
+			// Bytes are JSON encoded - match the legacy behavior
+			husky.AddTelemetryAttribute(ctx, "received_bytes_attr_type", true)
+			attrs[key] = addAttributeToMapAsJsonDirect(v)
+		case []any:
+			// Arrays are JSON encoded
+			husky.AddTelemetryAttribute(ctx, "received_array_attr_type", true)
+			attrs[key] = addAttributeToMapAsJsonDirect(v)
+		case map[string]any:
+			// Kvlists are flattened with dot notation
+			husky.AddTelemetryAttributes(ctx, map[string]any{
+				"received_kvlist_attr_type": true,
+				"kvlist_max_depth":          depth,
+			})
+			if depth < maxDepth {
+				// Flatten the kvlist
+				for k, v := range v {
+					flatKey := key + "." + k
+					switch vv := v.(type) {
+					case []byte:
+						attrs[flatKey] = addAttributeToMapAsJsonDirect(vv)
+					case []any:
+						attrs[flatKey] = addAttributeToMapAsJsonDirect(vv)
+					case map[string]any:
+						// Nested kvlist - would need recursive flattening
+						// For now, JSON encode it if we hit max depth
+						attrs[flatKey] = addAttributeToMapAsJsonDirect(vv)
+					default:
+						attrs[flatKey] = vv
+					}
+				}
+			} else {
+				// Max depth exceeded, JSON encode the whole thing
+				attrs[key] = addAttributeToMapAsJsonDirect(v)
+			}
+		default:
+			// Simple types - just assign directly
+			attrs[key] = value
+		}
+	}
+
+	return nil
+}
+
+// unmarshalAnyValue parses an AnyValue message
+func unmarshalAnyValue(ctx context.Context, data []byte) (any, error) {
+	l := len(data)
+	iNdEx := 0
+	var result any
+
+	// Handle empty message
+	if l == 0 {
+		return nil, nil
+	}
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return nil, err
+		}
+
+		switch fieldNum {
+		case 1: // string_value
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return nil, err
+			}
+			result = string(slice)
+
+		case 2: // bool_value
+			if wireType != 0 {
+				return nil, fmt.Errorf("proto: wrong wireType = %d for field BoolValue", wireType)
+			}
+			v := int(decodeVarint(data, &iNdEx))
+			result = v != 0
+
+		case 3: // int_value
+			if wireType != 0 {
+				return nil, fmt.Errorf("proto: wrong wireType = %d for field IntValue", wireType)
+			}
+			v := int64(decodeVarint(data, &iNdEx))
+			result = v
+
+		case 4: // double_value
+			v, err := decodeWireType1(data, &iNdEx, l, wireType)
+			if err != nil {
+				return nil, err
+			}
+			result = math.Float64frombits(v)
+
+		case 5: // array_value
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return nil, err
+			}
+			// Parse ArrayValue message and return as []any
+			arr, err := unmarshalArrayValue(ctx, slice)
+			if err != nil {
+				return nil, err
+			}
+			result = arr
+
+		case 6: // kvlist_value
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return nil, err
+			}
+			// Parse KeyValueList message and return as map[string]any
+			m, err := unmarshalKvlistValue(ctx, slice)
+			if err != nil {
+				return nil, err
+			}
+			result = m
+
+		case 7: // bytes_value
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return nil, err
+			}
+			// Match the behavior of the legacy code - return as []byte which will be JSON encoded later
+			// Make a copy of the slice to avoid issues with the underlying buffer
+			b := make([]byte, len(slice))
+			copy(b, slice)
+			result = b
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// unmarshalArrayValue parses an ArrayValue message and returns []any
+func unmarshalArrayValue(ctx context.Context, data []byte) ([]any, error) {
+	var values []any
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			// If we get EOF at the start of an empty message, return empty array
+			if err == io.ErrUnexpectedEOF && len(values) == 0 && iNdEx == 0 {
+				return values, nil
+			}
+			return nil, err
+		}
+
+		switch fieldNum {
+		case 1: // values (repeated)
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return nil, err
+			}
+			// Parse AnyValue
+			val, err := unmarshalAnyValue(ctx, slice)
+			if err != nil {
+				return nil, err
+			}
+			if val != nil {
+				values = append(values, val)
+			}
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return values, nil
+}
+
+// unmarshalKvlistValue parses a KeyValueList message and returns map[string]any
+func unmarshalKvlistValue(ctx context.Context, data []byte) (map[string]any, error) {
+	result := make(map[string]any)
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			// If we get EOF at the start of an empty message, return empty map
+			if err == io.ErrUnexpectedEOF && len(result) == 0 && iNdEx == 0 {
+				return result, nil
+			}
+			return nil, err
+		}
+
+		switch fieldNum {
+		case 1: // values (repeated KeyValue)
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return nil, err
+			}
+			// Parse KeyValue and add to map
+			if err := unmarshalKeyValue(ctx, slice, result, 0); err != nil {
+				return nil, err
+			}
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// unmarshalScopeSpans parses a ScopeSpans message
+func unmarshalScopeSpans(ctx context.Context, data []byte, ri RequestInfo, resourceAttrs map[string]any, dataset string, result *TranslateOTLPRequestResult) error {
+	scopeAttrs := make(map[string]any)
+
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return err
+		}
+
+		switch fieldNum {
+		case 1: // scope
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+			// Parse InstrumentationScope
+			err = unmarshalInstrumentationScope(ctx, slice, scopeAttrs)
+			if err != nil {
+				return err
+			}
+
+		case 2: // spans
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+			// Parse Span
+			err = unmarshalSpan(ctx, slice, ri, resourceAttrs, scopeAttrs, dataset, result)
+			if err != nil {
+				return err
+			}
+
+		case 3: // schema_url
+			_, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			// Skip the string value
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// unmarshalInstrumentationScope parses an InstrumentationScope message
+func unmarshalInstrumentationScope(ctx context.Context, data []byte, attrs map[string]any) error {
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return err
+		}
+
+		switch fieldNum {
+		case 1: // name
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			name := string(slice)
+			if name != "" {
+				attrs["library.name"] = name
+				if isInstrumentationLibrary(name) {
+					attrs["telemetry.instrumentation_library"] = true
+				}
+			}
+
+		case 2: // version
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			version := string(slice)
+			if version != "" {
+				attrs["library.version"] = version
+			}
+
+		case 3: // attributes
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+			// Parse KeyValue
+			err = unmarshalKeyValue(ctx, slice, attrs, 0)
+			if err != nil {
+				return err
+			}
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// unmarshalSpan parses a Span message and creates an event
+func unmarshalSpan(ctx context.Context, data []byte, ri RequestInfo, resourceAttrs, scopeAttrs map[string]any, dataset string, result *TranslateOTLPRequestResult) error {
+	// Find or create the batch for this dataset
+	var batch *Batch
+	for i := range result.Batches {
+		if result.Batches[i].Dataset == dataset {
+			batch = &result.Batches[i]
+			break
+		}
+	}
+	if batch == nil {
+		newBatch := Batch{
+			Dataset: dataset,
+			Events:  []Event{},
+		}
+		result.Batches = append(result.Batches, newBatch)
+		batch = &result.Batches[len(result.Batches)-1]
+	}
+
+	// Create event with resource and scope attributes
+	event := Event{
+		Attributes: make(map[string]any),
+		SampleRate: defaultSampleRate,
+	}
+
+	// Add resource attributes
+	for k, v := range resourceAttrs {
+		event.Attributes[k] = v
+	}
+
+	// Add scope attributes
+	for k, v := range scopeAttrs {
+		event.Attributes[k] = v
+	}
+
+	// Parse span fields
+	var traceID, spanID, parentSpanID []byte
+	var name, traceState string
+	var kind int32
+	var startTimeUnixNano, endTimeUnixNano uint64
+	var eventsData [][]byte // Collect event data to process later
+	var linksData [][]byte  // Collect link data to process later
+	var statusCode int      // Default to 0
+
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return err
+		}
+
+		switch fieldNum {
+		case 1: // trace_id
+			var err error
+			traceID, err = decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+		case 2: // span_id
+			var err error
+			spanID, err = decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+		case 3: // trace_state
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			traceState = string(slice)
+
+		case 4: // parent_span_id
+			var err error
+			parentSpanID, err = decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+		case 5: // name
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			name = string(slice)
+
+		case 6: // kind
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Kind", wireType)
+			}
+			kind = int32(decodeVarint(data, &iNdEx))
+
+		case 7: // start_time_unix_nano
+			v, err := decodeWireType1(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			startTimeUnixNano = v
+
+		case 8: // end_time_unix_nano
+			v, err := decodeWireType1(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			endTimeUnixNano = v
+
+		case 9: // attributes
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			// Parse KeyValue attribute
+			err = unmarshalKeyValue(ctx, slice, event.Attributes, 0)
+			if err != nil {
+				return err
+			}
+
+		case 11: // events
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			// Collect event data to process later
+			eventsData = append(eventsData, slice)
+
+		case 13: // links
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			// Collect link data to process later
+			linksData = append(linksData, slice)
+
+		case 15: // status
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			// Parse status
+			status, err := unmarshalStatus(ctx, slice)
+			if err != nil {
+				return err
+			}
+			// Parse status and update statusCode
+			if status != nil {
+				statusCode = int(status.code)
+				if status.message != "" {
+					event.Attributes["status_message"] = status.message
+				}
+				// Check if this is an error status
+				if status.code == 2 { // STATUS_CODE_ERROR
+					event.Attributes["error"] = true
+				}
+			}
+
+		default:
+			// Skip unknown fields and other fields we don't process yet
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Set span fields in the event
+	if len(traceID) > 0 {
+		event.Attributes["trace.trace_id"] = BytesToTraceID(traceID)
+	}
+	if len(spanID) > 0 {
+		event.Attributes["trace.span_id"] = BytesToSpanID(spanID)
+	}
+	if len(parentSpanID) > 0 {
+		event.Attributes["trace.parent_id"] = BytesToSpanID(parentSpanID)
+	}
+	event.Attributes["name"] = name
+	if traceState != "" {
+		event.Attributes["trace.trace_state"] = traceState
+	}
+
+	// Convert span kind
+	kindStr := spanKindToString(kind)
+	event.Attributes["span.kind"] = kindStr
+	event.Attributes["type"] = kindStr // Also add "type" for backward compatibility
+
+	// Add meta fields
+	event.Attributes["meta.signal_type"] = "trace"
+
+	// Add status code (always present, default 0)
+	event.Attributes["status_code"] = statusCode
+
+	// Add span event/link counts
+	event.Attributes["span.num_events"] = len(eventsData)
+	event.Attributes["span.num_links"] = len(linksData)
+
+	// Set timestamp to start time (default to epoch if not set)
+	event.Timestamp = timestampFromUnixNano(startTimeUnixNano)
+
+	// Calculate duration
+	duration := float64(0)
+	if startTimeUnixNano > 0 && endTimeUnixNano > 0 {
+		durationNs := float64(endTimeUnixNano - startTimeUnixNano)
+		duration = durationNs / float64(time.Millisecond)
+		if duration < 0 {
+			duration = 0
+			event.Attributes["meta.invalid_duration"] = true
+		}
+	}
+	event.Attributes["duration_ms"] = duration
+
+	// Get sample rate from trace state
+	event.SampleRate = getSampleRate(event.Attributes, traceState)
+
+	// Check if span has error status for propagation to events/links
+	isError := false
+	if errorVal, ok := event.Attributes["error"]; ok {
+		isError, _ = errorVal.(bool)
+	}
+
+	// Process span events first (before the main span)
+	for _, eventData := range eventsData {
+		err := unmarshalSpanEvent(ctx, eventData, traceID, spanID, name, startTimeUnixNano, resourceAttrs, scopeAttrs, event.SampleRate, isError, batch, event)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Process span links next
+	for _, linkData := range linksData {
+		err := unmarshalSpanLink(ctx, linkData, traceID, spanID, name, event.Timestamp, resourceAttrs, scopeAttrs, event.SampleRate, isError, batch)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Add the span event last (matching the order of regular unmarshaling)
+	batch.Events = append(batch.Events, event)
+
+	return nil
+}
+
+// unmarshalSpanEvent parses a Span.Event message and creates an event
+func unmarshalSpanEvent(ctx context.Context, data []byte, traceID, parentSpanID []byte, parentName string, spanStartTime uint64, resourceAttrs, scopeAttrs map[string]any, sampleRate int32, isError bool, batch *Batch, parentSpan Event) error {
+	// Create event with resource and scope attributes
+	event := Event{
+		Attributes: make(map[string]any),
+		SampleRate: sampleRate,
+	}
+
+	// Add resource attributes
+	for k, v := range resourceAttrs {
+		event.Attributes[k] = v
+	}
+
+	// Add scope attributes
+	for k, v := range scopeAttrs {
+		event.Attributes[k] = v
+	}
+
+	// Set trace info
+	if len(traceID) > 0 {
+		event.Attributes["trace.trace_id"] = BytesToTraceID(traceID)
+	}
+	if len(parentSpanID) > 0 {
+		event.Attributes["trace.parent_id"] = BytesToSpanID(parentSpanID)
+	}
+
+	// Don't generate a span ID for span events - they only have parent_id
+
+	// Mark as span event
+	event.Attributes["meta.annotation_type"] = "span_event"
+	event.Attributes["meta.signal_type"] = "trace"
+	if parentName != "" {
+		event.Attributes["parent_name"] = parentName
+	}
+
+	// Parse event fields
+	var name string
+	var timeUnixNano uint64
+
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return err
+		}
+
+		switch fieldNum {
+		case 1: // time_unix_nano
+			v, err := decodeWireType1(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			timeUnixNano = v
+
+		case 2: // name
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			name = string(slice)
+
+		case 3: // attributes
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			// Parse KeyValue attribute
+			err = unmarshalKeyValue(ctx, slice, event.Attributes, 0)
+			if err != nil {
+				return err
+			}
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Set event name
+	event.Attributes["name"] = name
+
+	// Set timestamp
+	if timeUnixNano > 0 {
+		event.Timestamp = timestampFromUnixNano(timeUnixNano)
+	}
+
+	// Calculate duration relative to span start
+	if timeUnixNano > 0 && spanStartTime > 0 {
+		timeSinceSpanStart := float64(timeUnixNano-spanStartTime) / float64(time.Millisecond)
+		if timeSinceSpanStart < 0 {
+			timeSinceSpanStart = 0
+			event.Attributes["meta.invalid_time_since_span_start"] = true
+		}
+		event.Attributes["meta.time_since_span_start_ms"] = timeSinceSpanStart
+	}
+
+	// Add error status from parent span if applicable
+	if isError {
+		event.Attributes["error"] = true
+	}
+
+	// Handle exception events specially
+	if name == "exception" {
+		// Copy exception attributes to parent span
+		for k, v := range event.Attributes {
+			switch k {
+			case "exception.message", "exception.type", "exception.stacktrace", "exception.escaped":
+				// Don't overwrite if the value is already on the span
+				if _, present := parentSpan.Attributes[k]; !present {
+					parentSpan.Attributes[k] = v
+				}
+			}
+		}
+	}
+
+	batch.Events = append(batch.Events, event)
+	return nil
+}
+
+// unmarshalSpanLink parses a Span.Link message and creates an event
+func unmarshalSpanLink(ctx context.Context, data []byte, traceID, parentSpanID []byte, parentName string, parentTimestamp time.Time, resourceAttrs, scopeAttrs map[string]any, sampleRate int32, isError bool, batch *Batch) error {
+	// Create event with resource and scope attributes
+	event := Event{
+		Attributes: make(map[string]any),
+		SampleRate: sampleRate,
+		Timestamp:  parentTimestamp, // use timestamp from parent span
+	}
+
+	// Add resource attributes
+	for k, v := range resourceAttrs {
+		event.Attributes[k] = v
+	}
+
+	// Add scope attributes
+	for k, v := range scopeAttrs {
+		event.Attributes[k] = v
+	}
+
+	// Set trace info
+	if len(traceID) > 0 {
+		event.Attributes["trace.trace_id"] = BytesToTraceID(traceID)
+	}
+	if len(parentSpanID) > 0 {
+		event.Attributes["trace.parent_id"] = BytesToSpanID(parentSpanID)
+	}
+
+	// Don't generate a span ID for span links - they only have parent_id
+
+	// Mark as link
+	event.Attributes["meta.annotation_type"] = "link"
+	event.Attributes["meta.signal_type"] = "trace"
+	if parentName != "" {
+		event.Attributes["parent_name"] = parentName
+	}
+
+	// Parse link fields
+	var linkedTraceID, linkedSpanID []byte
+
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		fieldNum, wireType, err := decodeField(data, &iNdEx)
+		if err != nil {
+			return err
+		}
+
+		switch fieldNum {
+		case 1: // trace_id
+			var err error
+			linkedTraceID, err = decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+		case 2: // span_id
+			var err error
+			linkedSpanID, err = decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+		case 3: // trace_state
+			// Skip trace_state - original implementation doesn't add it
+			_, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+
+		case 4: // attributes
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+			// Parse KeyValue attribute
+			err = unmarshalKeyValue(ctx, slice, event.Attributes, 0)
+			if err != nil {
+				return err
+			}
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Set link fields
+	if len(linkedTraceID) > 0 {
+		event.Attributes["trace.link.trace_id"] = BytesToTraceID(linkedTraceID)
+	}
+	if len(linkedSpanID) > 0 {
+		event.Attributes["trace.link.span_id"] = hex.EncodeToString(linkedSpanID)
+	}
+	// Note: The original implementation doesn't add trace.link.trace_state
+	// even though it's part of the OTLP spec, so we skip it for compatibility
+
+	// Add error status from parent span if applicable
+	if isError {
+		event.Attributes["error"] = true
+	}
+
+	batch.Events = append(batch.Events, event)
+	return nil
+}
+
+var eventCounter uint64
+
+// generateSpanID generates a unique 8-byte span ID for events
+func generateSpanID() []byte {
+	eventCounter++
+	spanID := make([]byte, 8)
+	// Simple deterministic ID based on counter
+	spanID[0] = 0xff // Marker to distinguish from regular span IDs
+	spanID[1] = byte(eventCounter >> 40)
+	spanID[2] = byte(eventCounter >> 32)
+	spanID[3] = byte(eventCounter >> 24)
+	spanID[4] = byte(eventCounter >> 16)
+	spanID[5] = byte(eventCounter >> 8)
+	spanID[6] = byte(eventCounter)
+	spanID[7] = 0x00
+	return spanID
+}
+
+// spanStatus represents the status of a span
+type spanStatus struct {
+	code    int32
+	message string
+}
+
+// spanKindToString converts a span kind enum to string
+func spanKindToString(kind int32) string {
+	switch kind {
+	case 0:
+		return "unspecified" // SPAN_KIND_UNSPECIFIED
+	case 1:
+		return "internal"
+	case 2:
+		return "server"
+	case 3:
+		return "client"
+	case 4:
+		return "producer"
+	case 5:
+		return "consumer"
+	default:
+		return "unspecified"
+	}
+}
+
+// unmarshalStatus parses a Status message
+func unmarshalStatus(ctx context.Context, data []byte) (*spanStatus, error) {
+	var status spanStatus
+
+	l := len(data)
+	iNdEx := 0
+
+	for iNdEx < l {
+		preIndex := iNdEx
+		wire := decodeVarint(data, &iNdEx)
+		if iNdEx == preIndex {
+			return nil, io.ErrUnexpectedEOF
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+
+		switch fieldNum {
+		case 2: // message
+			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
+			if err != nil {
+				return nil, err
+			}
+			status.message = string(slice)
+
+		case 3: // code
+			if wireType != 0 {
+				return nil, fmt.Errorf("proto: wrong wireType = %d for field Code", wireType)
+			}
+			status.code = int32(decodeVarint(data, &iNdEx))
+
+		default:
+			// Skip unknown fields
+			if err := skipUnknownField(data, &iNdEx, preIndex, l); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &status, nil
+}
+
+// timestampFromUnixNano converts unix nano timestamp to time.Time
+func timestampFromUnixNano(unixNano uint64) time.Time {
+	return time.Unix(0, int64(unixNano)).UTC()
+}
+
+// decodeWireType2 decodes a length-delimited field (wire type 2) and returns
+// a sub-slice of the original data without copying. The iNdEx is advanced past
+// the field data. It also validates that the wire type is correct.
+func decodeWireType2(data []byte, iNdEx *int, l int, wireType int) ([]byte, error) {
+	if wireType != 2 {
+		return nil, fmt.Errorf("proto: wrong wireType = %d for field", wireType)
+	}
+	msglen := int(decodeVarint(data, iNdEx))
+	if msglen < 0 {
+		return nil, ErrInvalidLength
+	}
+	postIndex := *iNdEx + msglen
+	if postIndex < 0 {
+		return nil, ErrInvalidLength
+	}
+	if postIndex > l {
+		return nil, io.ErrUnexpectedEOF
+	}
+	slice := data[*iNdEx:postIndex]
+	*iNdEx = postIndex
+	return slice, nil
+}
+
+// decodeWireType1 decodes a 64-bit fixed field (wire type 1) and returns the
+// value as uint64. The iNdEx is advanced by 8 bytes. It also validates that
+// the wire type is correct.
+func decodeWireType1(data []byte, iNdEx *int, l int, wireType int) (uint64, error) {
+	if wireType != 1 {
+		return 0, fmt.Errorf("proto: wrong wireType = %d for field", wireType)
+	}
+	if (*iNdEx + 8) > l {
+		return 0, io.ErrUnexpectedEOF
+	}
+	v := uint64(data[*iNdEx])
+	v |= uint64(data[*iNdEx+1]) << 8
+	v |= uint64(data[*iNdEx+2]) << 16
+	v |= uint64(data[*iNdEx+3]) << 24
+	v |= uint64(data[*iNdEx+4]) << 32
+	v |= uint64(data[*iNdEx+5]) << 40
+	v |= uint64(data[*iNdEx+6]) << 48
+	v |= uint64(data[*iNdEx+7]) << 56
+	*iNdEx += 8
+	return v, nil
+}
+
+// skipUnknownField skips an unknown field in the protobuf wire format.
+// TODO we need a test which actually contains serialized unknown fields.
+func skipUnknownField(data []byte, iNdEx *int, preIndex int, l int) error {
+	*iNdEx = preIndex
+	depth := 0
+	for *iNdEx < l {
+		_, wireType, err := decodeField(data, iNdEx)
+		if err != nil {
+			return err
+		}
+		switch wireType {
+		case 0:
+			_ = decodeVarint(data, iNdEx)
+		case 1:
+			*iNdEx += 8
+		case 2:
+			_, err := decodeWireType2(data, iNdEx, l, wireType)
+			if err != nil {
+				return err
+			}
+		case 3:
+			depth++
+		case 4:
+			if depth == 0 {
+				return ErrUnexpectedEndOfGroup
+			}
+			depth--
+		case 5:
+			*iNdEx += 4
+		default:
+			return fmt.Errorf("proto: illegal wireType %d", wireType)
+		}
+		if *iNdEx < 0 {
+			return ErrInvalidLength
+		}
+		if depth == 0 {
+			return nil
+		}
+	}
+	return io.ErrUnexpectedEOF
+}
+
+func decodeVarint(data []byte, iNdEx *int) uint64 {
+	var res uint64
+	startIdx := *iNdEx
+	for shift := uint(0); shift < 64; shift += 7 {
+		if *iNdEx >= len(data) {
+			// Reset index to start position if we can't read a complete varint
+			*iNdEx = startIdx
+			return 0
+		}
+		b := data[*iNdEx]
+		*iNdEx++
+		res |= (uint64(b) & 0x7F) << shift
+		if (b & 0x80) == 0 {
+			return res
+		}
+	}
+
+	// The number is too large to represent in a 64-bit value.
+	return 0
+}
+
+func decodeField(data []byte, iNdEx *int) (fieldNum int32, wireType int, err error) {
+	preIndex := *iNdEx
+	wire := decodeVarint(data, iNdEx)
+	if *iNdEx == preIndex {
+		return 0, 0, io.ErrUnexpectedEOF
+	}
+	fieldNum = int32(wire >> 3)
+	wireType = int(wire & 0x7)
+
+	if fieldNum <= 0 {
+		return 0, 0, fmt.Errorf("proto: illegal tag %d (wire type %d)", fieldNum, wireType)
+	}
+	return
+}
+
+// addAttributeToMapAsJsonDirect converts a value to JSON string, matching the behavior
+// of the legacy addAttributeToMapAsJson function
+func addAttributeToMapAsJsonDirect(val any) string {
+	// Convert bytes to base64 if needed
+	if bytes, ok := val.([]byte); ok {
+		val = base64.StdEncoding.EncodeToString(bytes)
+	}
+
+	// Use json-iterator for consistency with legacy code
+	// fieldSizeMax = math.MaxUint16 from common.go
+	w := newLimitedWriter(math.MaxUint16)
+	e := json.NewEncoder(w)
+	e.SetEscapeHTML(false)
+	if err := e.Encode(val); err != nil {
+		// Return empty string on error to match legacy behavior
+		return ""
+	}
+	return w.String()
+}

--- a/otlp/traces_direct.go
+++ b/otlp/traces_direct.go
@@ -96,6 +96,7 @@ import (
 	"time"
 
 	"github.com/honeycombio/husky"
+
 	"github.com/tinylib/msgp/msgp"
 	trace "go.opentelemetry.io/proto/otlp/trace/v1"
 )
@@ -169,21 +170,18 @@ func (m *msgpAttributes) addString(key []byte, value []byte) {
 	m.count++
 }
 
-// addInt64 adds a string key with int64 value
 func (m *msgpAttributes) addInt64(key []byte, value int64) {
 	m.buf = msgp.AppendStringFromBytes(m.buf, key)
 	m.buf = msgp.AppendInt64(m.buf, value)
 	m.count++
 }
 
-// addFloat64 adds a string key with float64 value
 func (m *msgpAttributes) addFloat64(key []byte, value float64) {
 	m.buf = msgp.AppendStringFromBytes(m.buf, key)
 	m.buf = msgp.AppendFloat64(m.buf, value)
 	m.count++
 }
 
-// addBool adds a string key with bool value
 func (m *msgpAttributes) addBool(key []byte, value bool) {
 	m.buf = msgp.AppendStringFromBytes(m.buf, key)
 	m.buf = msgp.AppendBool(m.buf, value)
@@ -305,7 +303,6 @@ func unmarshalTraceRequestDirectMsgp(ctx context.Context, data []byte, ri Reques
 			}
 
 		default:
-			// Skip unknown fields
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return nil, err
 			}
@@ -425,7 +422,6 @@ func unmarshalResource(ctx context.Context, data []byte, attrs *msgpAttributes) 
 			}
 
 		default:
-			// Skip unknown fields
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return err
 			}
@@ -464,7 +460,6 @@ func parseKeyValue(data []byte) ([]byte, []byte, error) {
 			}
 
 		default:
-			// Skip unknown fields
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return nil, nil, err
 			}
@@ -737,7 +732,6 @@ func unmarshalAnyValue(ctx context.Context, data []byte) (any, error) {
 			result = b
 
 		default:
-			// Skip unknown fields
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return nil, err
 			}
@@ -780,7 +774,6 @@ func unmarshalArrayValue(ctx context.Context, data []byte) ([]any, error) {
 			}
 
 		default:
-			// Skip unknown fields
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return nil, err
 			}
@@ -840,7 +833,6 @@ func unmarshalKvlistValue(ctx context.Context, data []byte) (map[string]any, err
 			}
 
 		default:
-			// Skip unknown fields
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return nil, err
 			}
@@ -968,7 +960,6 @@ func unmarshalInstrumentationScope(ctx context.Context, data []byte, attrs *msgp
 			}
 
 		default:
-			// Skip unknown fields
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return err
 			}
@@ -1158,7 +1149,6 @@ func unmarshalSpan(
 					}
 
 				default:
-					// Skip unknown fields
 					if err := skipField(slice, &siNdEx, sPreIndex, sl); err != nil {
 						return err
 					}
@@ -1166,7 +1156,6 @@ func unmarshalSpan(
 			}
 
 		default:
-			// Skip unknown fields and other fields we don't process yet
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return err
 			}
@@ -1318,7 +1307,6 @@ func unmarshalSpanEvent(
 			}
 
 		default:
-			// Skip unknown fields
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return nil, err
 			}
@@ -1506,7 +1494,6 @@ func unmarshalSpanLink(
 			}
 
 		default:
-			// Skip unknown fields
 			if err := skipField(data, &iNdEx, preIndex, l); err != nil {
 				return err
 			}

--- a/otlp/traces_direct.go
+++ b/otlp/traces_direct.go
@@ -1,5 +1,8 @@
 package otlp
 
+// Translates OTLP traces into honeycomb's event format, including a serialized
+// messagepack attribute map per event, instead of a fully deserialized one.
+
 // OTLP Trace Protobuf Structure:
 //
 // ExportTraceServiceRequest
@@ -257,14 +260,14 @@ func (m *msgpAttributesMap) finalize() ([]byte, error) {
 	return slices.Clone(m.buf), nil
 }
 
-// UnmarshalTraceRequestDirectMsgp translates a serialized OTLP trace request directly
+// unmarshalTraceRequestDirectMsgp translates a serialized OTLP trace request directly
 // into a Honeycomb-friendly structure without creating intermediate proto structs,
 // which is EXTREMELY expensive.
 // Why does the code look like this? Because it's derived from gogo's generated
 // code, and carries over some of the style conventions so that it will hopefully
 // be relatively easy to update it in future, should that be necessary.
 // Fortunately this part of OTLP is marked as "stable" so we don't expect changes.
-func UnmarshalTraceRequestDirectMsgp(ctx context.Context, data []byte, ri RequestInfo) (*TranslateOTLPRequestResultMsgp, error) {
+func unmarshalTraceRequestDirectMsgp(ctx context.Context, data []byte, ri RequestInfo) (*TranslateOTLPRequestResultMsgp, error) {
 	if err := ri.ValidateTracesHeaders(); err != nil {
 		return nil, err
 	}

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -1,0 +1,1152 @@
+package otlp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	common "go.opentelemetry.io/proto/otlp/common/v1"
+	resource "go.opentelemetry.io/proto/otlp/resource/v1"
+	trace "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func TestUnmarshalTraceRequestDirect_Empty(t *testing.T) {
+	// Create an empty request
+	req := &collectortrace.ExportTraceServiceRequest{}
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, len(data), result.RequestSize)
+	assert.Empty(t, result.Batches)
+}
+
+func TestUnmarshalTraceRequestDirect_WithResourceSpans(t *testing.T) {
+	// Create a request with ResourceSpans but no actual spans
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{},
+			{},
+		},
+	}
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, len(data), result.RequestSize)
+	// No batches yet since we don't parse spans
+	assert.Empty(t, result.Batches)
+}
+
+func TestUnmarshalTraceRequestDirect_WithResource(t *testing.T) {
+	// Create a request with ResourceSpans including resource attributes
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{
+				Resource: &resource.Resource{
+					Attributes: []*common.KeyValue{
+						{
+							Key: "service.name",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+							},
+						},
+						{
+							Key: "resource.attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "resource-value"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	// No batches yet since we don't parse spans
+	assert.Empty(t, result.Batches)
+}
+
+func TestUnmarshalTraceRequestDirect_WithScopeSpans(t *testing.T) {
+	// Create a request with ScopeSpans and InstrumentationScope
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{
+				Resource: &resource.Resource{
+					Attributes: []*common.KeyValue{
+						{
+							Key: "service.name",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+							},
+						},
+					},
+				},
+				ScopeSpans: []*trace.ScopeSpans{
+					{
+						Scope: &common.InstrumentationScope{
+							Name:    "test-library",
+							Version: "1.0.0",
+							Attributes: []*common.KeyValue{
+								{
+									Key: "scope.attr",
+									Value: &common.AnyValue{
+										Value: &common.AnyValue_StringValue{StringValue: "scope-value"},
+									},
+								},
+							},
+						},
+						// We'll add spans in the next test
+					},
+				},
+			},
+		},
+	}
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	// No batches yet since we don't parse spans
+	assert.Empty(t, result.Batches)
+}
+
+func TestUnmarshalTraceRequestDirect_WithBasicSpan(t *testing.T) {
+	// Create a simple span
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+	// Expected duration: (1234567890987654321 - 1234567890123456789) = 864197532 ns = 864.197532 ms ≈ 864 ms
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{
+				Resource: &resource.Resource{
+					Attributes: []*common.KeyValue{
+						{
+							Key: "service.name",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+							},
+						},
+					},
+				},
+				ScopeSpans: []*trace.ScopeSpans{
+					{
+						Scope: &common.InstrumentationScope{
+							Name:    "test-library",
+							Version: "1.0.0",
+						},
+						Spans: []*trace.Span{
+							{
+								TraceId:           traceID,
+								SpanId:            spanID,
+								Name:              "test-span",
+								Kind:              trace.Span_SPAN_KIND_CLIENT,
+								StartTimeUnixNano: startTime,
+								EndTimeUnixNano:   endTime,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Batches, 1)
+	
+	batch := result.Batches[0]
+	assert.Equal(t, "test-service", batch.Dataset)
+	assert.Len(t, batch.Events, 1)
+	
+	event := batch.Events[0]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
+	assert.Equal(t, "test-span", event.Attributes["name"])
+	assert.Equal(t, "client", event.Attributes["span.kind"])
+	assert.InDelta(t, float64(864.197532), event.Attributes["duration_ms"], 0.01)
+	assert.Equal(t, "test-library", event.Attributes["library.name"])
+	assert.Equal(t, "1.0.0", event.Attributes["library.version"])
+	assert.Equal(t, "test-service", event.Attributes["service.name"])
+}
+
+func TestUnmarshalTraceRequestDirect_WithSpanAttributesAndStatus(t *testing.T) {
+	// Create a span with attributes and status
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	parentSpanID := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{
+				Resource: &resource.Resource{
+					Attributes: []*common.KeyValue{
+						{
+							Key: "service.name",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+							},
+						},
+					},
+				},
+				ScopeSpans: []*trace.ScopeSpans{
+					{
+						Scope: &common.InstrumentationScope{
+							Name:    "test-library",
+							Version: "1.0.0",
+						},
+						Spans: []*trace.Span{
+							{
+								TraceId:           traceID,
+								SpanId:            spanID,
+								ParentSpanId:      parentSpanID,
+								TraceState:        "w3c=true",
+								Name:              "test-span",
+								Kind:              trace.Span_SPAN_KIND_SERVER,
+								StartTimeUnixNano: startTime,
+								EndTimeUnixNano:   endTime,
+								Attributes: []*common.KeyValue{
+									{
+										Key: "http.method",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_StringValue{StringValue: "GET"},
+										},
+									},
+									{
+										Key: "http.status_code",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_IntValue{IntValue: 200},
+										},
+									},
+									{
+										Key: "http.url",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_StringValue{StringValue: "https://example.com/api/v1/users"},
+										},
+									},
+									{
+										Key: "response.size",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_DoubleValue{DoubleValue: 1234.56},
+										},
+									},
+									{
+										Key: "success",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_BoolValue{BoolValue: true},
+										},
+									},
+									{
+										Key: "sampleRate",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_IntValue{IntValue: 10},
+										},
+									},
+								},
+								Status: &trace.Status{
+									Code:    trace.Status_STATUS_CODE_OK,
+									Message: "Request completed successfully",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Batches, 1)
+	
+	batch := result.Batches[0]
+	assert.Equal(t, "test-service", batch.Dataset)
+	assert.Len(t, batch.Events, 1)
+	
+	event := batch.Events[0]
+	// Basic fields
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
+	assert.Equal(t, "1112131415161718", event.Attributes["trace.parent_id"])
+	assert.Equal(t, "w3c=true", event.Attributes["trace.trace_state"])
+	assert.Equal(t, "test-span", event.Attributes["name"])
+	assert.Equal(t, "server", event.Attributes["span.kind"])
+	
+	// Span attributes
+	assert.Equal(t, "GET", event.Attributes["http.method"])
+	assert.Equal(t, int64(200), event.Attributes["http.status_code"])
+	assert.Equal(t, "https://example.com/api/v1/users", event.Attributes["http.url"])
+	assert.Equal(t, float64(1234.56), event.Attributes["response.size"])
+	assert.Equal(t, true, event.Attributes["success"])
+	
+	// Status
+	assert.Equal(t, 1, event.Attributes["status_code"]) // STATUS_CODE_OK = 1
+	assert.Equal(t, "Request completed successfully", event.Attributes["status_message"])
+	
+	// Sample rate should be extracted from attributes
+	assert.Equal(t, int32(10), event.SampleRate)
+	// sampleRate attribute should be removed
+	assert.Nil(t, event.Attributes["sampleRate"])
+}
+
+func TestUnmarshalTraceRequestDirect_WithSpanEvents(t *testing.T) {
+	// Create a span with events
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+	event1Time := uint64(1234567890123456789 + 100_000_000) // 100ms after start
+	event2Time := uint64(1234567890123456789 + 200_000_000) // 200ms after start
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{
+				Resource: &resource.Resource{
+					Attributes: []*common.KeyValue{
+						{
+							Key: "service.name",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+							},
+						},
+					},
+				},
+				ScopeSpans: []*trace.ScopeSpans{
+					{
+						Scope: &common.InstrumentationScope{
+							Name: "test-library",
+						},
+						Spans: []*trace.Span{
+							{
+								TraceId:           traceID,
+								SpanId:            spanID,
+								Name:              "test-span",
+								Kind:              trace.Span_SPAN_KIND_SERVER,
+								StartTimeUnixNano: startTime,
+								EndTimeUnixNano:   endTime,
+								Events: []*trace.Span_Event{
+									{
+										TimeUnixNano: event1Time,
+										Name:         "cache_miss", 
+										Attributes: []*common.KeyValue{
+											{
+												Key: "cache.key",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "user:123"},
+												},
+											},
+											{
+												Key: "cache.ttl",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_IntValue{IntValue: 3600},
+												},
+											},
+										},
+									},
+									{
+										TimeUnixNano: event2Time,
+										Name:         "exception",
+										Attributes: []*common.KeyValue{
+											{
+												Key: "exception.type",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "ValueError"},
+												},
+											},
+											{
+												Key: "exception.message",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "Invalid input"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Batches, 1)
+	
+	batch := result.Batches[0]
+	assert.Equal(t, "test-service", batch.Dataset)
+	// Should have 3 events: 1 span + 2 span events
+	assert.Len(t, batch.Events, 3)
+	
+	// First event is the cache_miss event
+	event1 := batch.Events[0]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event1.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", event1.Attributes["trace.parent_id"]) // parent is the span
+	assert.Nil(t, event1.Attributes["trace.span_id"]) // span events don't have their own span ID
+	assert.Equal(t, "cache_miss", event1.Attributes["name"])
+	assert.Equal(t, "span_event", event1.Attributes["meta.annotation_type"])
+	assert.Equal(t, "user:123", event1.Attributes["cache.key"])
+	assert.Equal(t, int64(3600), event1.Attributes["cache.ttl"])
+	assert.Equal(t, float64(100), event1.Attributes["meta.time_since_span_start_ms"]) // relative to span start
+	
+	// Second event is the exception event  
+	event2 := batch.Events[1]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event2.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", event2.Attributes["trace.parent_id"])
+	assert.Nil(t, event2.Attributes["trace.span_id"]) // span events don't have their own span ID
+	assert.Equal(t, "exception", event2.Attributes["name"])
+	assert.Equal(t, "span_event", event2.Attributes["meta.annotation_type"])
+	assert.Equal(t, "ValueError", event2.Attributes["exception.type"])
+	assert.Equal(t, "Invalid input", event2.Attributes["exception.message"])
+	assert.Equal(t, float64(200), event2.Attributes["meta.time_since_span_start_ms"])
+	
+	// Third event is the span itself
+	spanEvent := batch.Events[2]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", spanEvent.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", spanEvent.Attributes["trace.span_id"])
+	assert.Equal(t, "test-span", spanEvent.Attributes["name"])
+}
+
+func TestUnmarshalTraceRequestDirect_WithSpanLinks(t *testing.T) {
+	// Create a span with links
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	linkedTraceID1 := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20}
+	linkedSpanID1 := []byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28}
+	linkedTraceID2 := []byte{0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40}
+	linkedSpanID2 := []byte{0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48}
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{
+				Resource: &resource.Resource{
+					Attributes: []*common.KeyValue{
+						{
+							Key: "service.name",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+							},
+						},
+					},
+				},
+				ScopeSpans: []*trace.ScopeSpans{
+					{
+						Scope: &common.InstrumentationScope{
+							Name: "test-library",
+						},
+						Spans: []*trace.Span{
+							{
+								TraceId:           traceID,
+								SpanId:            spanID,
+								Name:              "test-span",
+								Kind:              trace.Span_SPAN_KIND_SERVER,
+								StartTimeUnixNano: startTime,
+								EndTimeUnixNano:   endTime,
+								Links: []*trace.Span_Link{
+									{
+										TraceId:    linkedTraceID1,
+										SpanId:     linkedSpanID1,
+										TraceState: "vendor1=value1",
+										Attributes: []*common.KeyValue{
+											{
+												Key: "link.type",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "parent"},
+												},
+											},
+										},
+									},
+									{
+										TraceId:    linkedTraceID2,
+										SpanId:     linkedSpanID2,
+										TraceState: "vendor2=value2",
+										Attributes: []*common.KeyValue{
+											{
+												Key: "link.type",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "child"},
+												},
+											},
+											{
+												Key: "link.service",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "downstream-service"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Batches, 1)
+	
+	batch := result.Batches[0]
+	assert.Equal(t, "test-service", batch.Dataset)
+	// Should have 3 events: 1 span + 2 span links
+	assert.Len(t, batch.Events, 3)
+	
+	// First event is the first link
+	link1 := batch.Events[0]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", link1.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", link1.Attributes["trace.parent_id"]) // parent is the span
+	assert.Nil(t, link1.Attributes["trace.span_id"]) // span links don't have their own span ID
+	assert.Equal(t, "1112131415161718191a1b1c1d1e1f20", link1.Attributes["trace.link.trace_id"])
+	assert.Equal(t, "2122232425262728", link1.Attributes["trace.link.span_id"])
+	// trace.link.trace_state is not added by the implementation
+	assert.Equal(t, "link", link1.Attributes["meta.annotation_type"])
+	assert.Equal(t, "parent", link1.Attributes["link.type"])
+	
+	// Second event is the second link  
+	link2 := batch.Events[1]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", link2.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", link2.Attributes["trace.parent_id"])
+	assert.Nil(t, link2.Attributes["trace.span_id"]) // span links don't have their own span ID
+	assert.Equal(t, "3132333435363738393a3b3c3d3e3f40", link2.Attributes["trace.link.trace_id"])
+	assert.Equal(t, "4142434445464748", link2.Attributes["trace.link.span_id"])
+	// trace.link.trace_state is not added by the implementation
+	assert.Equal(t, "link", link2.Attributes["meta.annotation_type"])
+	assert.Equal(t, "child", link2.Attributes["link.type"])
+	assert.Equal(t, "downstream-service", link2.Attributes["link.service"])
+	
+	// Third event is the span itself
+	spanEvent := batch.Events[2]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", spanEvent.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", spanEvent.Attributes["trace.span_id"])
+	assert.Equal(t, "test-span", spanEvent.Attributes["name"])
+}
+
+func TestTranslateTraceRequestFromReaderDirect(t *testing.T) {
+	// Create a test request with all features we support
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	parentSpanID := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+	eventTime := uint64(1234567890123456789 + 100_000_000) // 100ms after start
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{
+				Resource: &resource.Resource{
+					Attributes: []*common.KeyValue{
+						{
+							Key: "service.name",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+							},
+						},
+						{
+							Key: "deployment.environment", 
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "production"},
+							},
+						},
+					},
+				},
+				ScopeSpans: []*trace.ScopeSpans{
+					{
+						Scope: &common.InstrumentationScope{
+							Name:    "test-library",
+							Version: "1.0.0",
+						},
+						Spans: []*trace.Span{
+							{
+								TraceId:           traceID,
+								SpanId:            spanID,
+								ParentSpanId:      parentSpanID,
+								TraceState:        "w3c=true",
+								Name:              "HTTP GET /api/users",
+								Kind:              trace.Span_SPAN_KIND_SERVER,
+								StartTimeUnixNano: startTime,
+								EndTimeUnixNano:   endTime,
+								Attributes: []*common.KeyValue{
+									{
+										Key: "http.method",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_StringValue{StringValue: "GET"},
+										},
+									},
+									{
+										Key: "http.status_code",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_IntValue{IntValue: 200},
+										},
+									},
+									{
+										Key: "sampleRate",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_IntValue{IntValue: 10},
+										},
+									},
+								},
+								Status: &trace.Status{
+									Code:    trace.Status_STATUS_CODE_OK,
+									Message: "Success",
+								},
+								Events: []*trace.Span_Event{
+									{
+										TimeUnixNano: eventTime,
+										Name:         "db_query",
+										Attributes: []*common.KeyValue{
+											{
+												Key: "db.statement",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "SELECT * FROM users"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Serialize the request
+	data := serializeTraceRequest(t, req)
+	
+	// Create a reader from the data
+	body := io.NopCloser(bytes.NewReader(data))
+	
+	// Create request info
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+	
+	// Call the new direct function
+	result, err := TranslateTraceRequestFromReaderDirect(context.Background(), body, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Greater(t, result.RequestSize, 0)
+	assert.Len(t, result.Batches, 1)
+	
+	batch := result.Batches[0]
+	assert.Equal(t, "test-service", batch.Dataset)
+	// Should have 2 events: 1 span + 1 span event
+	assert.Len(t, batch.Events, 2)
+	
+	// First event should be the span event (db_query)
+	dbEvent := batch.Events[0]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", dbEvent.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", dbEvent.Attributes["trace.parent_id"])
+	assert.Nil(t, dbEvent.Attributes["trace.span_id"]) // span events don't have their own span ID
+	assert.Equal(t, "db_query", dbEvent.Attributes["name"])
+	assert.Equal(t, "span_event", dbEvent.Attributes["meta.annotation_type"])
+	assert.Equal(t, "SELECT * FROM users", dbEvent.Attributes["db.statement"])
+	assert.Equal(t, float64(100), dbEvent.Attributes["meta.time_since_span_start_ms"])
+	assert.Equal(t, int32(10), dbEvent.SampleRate)
+	
+	// Second event should be the main span
+	spanEvent := batch.Events[1]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", spanEvent.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", spanEvent.Attributes["trace.span_id"])
+	assert.Equal(t, "1112131415161718", spanEvent.Attributes["trace.parent_id"])
+	assert.Equal(t, "HTTP GET /api/users", spanEvent.Attributes["name"])
+	assert.Equal(t, "server", spanEvent.Attributes["span.kind"])
+	assert.Equal(t, "GET", spanEvent.Attributes["http.method"])
+	assert.Equal(t, int64(200), spanEvent.Attributes["http.status_code"])
+	assert.Equal(t, 1, spanEvent.Attributes["status_code"]) // STATUS_CODE_OK = 1
+	assert.Equal(t, "Success", spanEvent.Attributes["status_message"])
+	assert.Equal(t, int32(10), spanEvent.SampleRate)
+	assert.Equal(t, "production", spanEvent.Attributes["deployment.environment"])
+}
+
+func TestCompareDirectVsRegularUnmarshaling(t *testing.T) {
+	// Create a complex test request
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	parentSpanID := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+	eventTime := uint64(1234567890123456789 + 100_000_000)
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{
+				Resource: &resource.Resource{
+					Attributes: []*common.KeyValue{
+						{
+							Key: "service.name",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+							},
+						},
+						{
+							Key: "resource.attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "resource-value"},
+							},
+						},
+					},
+				},
+				ScopeSpans: []*trace.ScopeSpans{
+					{
+						Scope: &common.InstrumentationScope{
+							Name:    "test-library",
+							Version: "1.0.0",
+							Attributes: []*common.KeyValue{
+								{
+									Key: "scope.attr",
+									Value: &common.AnyValue{
+										Value: &common.AnyValue_StringValue{StringValue: "scope-value"},
+									},
+								},
+							},
+						},
+						Spans: []*trace.Span{
+							{
+								TraceId:           traceID,
+								SpanId:            spanID,
+								ParentSpanId:      parentSpanID,
+								TraceState:        "w3c=true",
+								Name:              "test-span",
+								Kind:              trace.Span_SPAN_KIND_SERVER,
+								StartTimeUnixNano: startTime,
+								EndTimeUnixNano:   endTime,
+								Attributes: []*common.KeyValue{
+									{
+										Key: "http.method",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_StringValue{StringValue: "GET"},
+										},
+									},
+									{
+										Key: "sampleRate",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_IntValue{IntValue: 10},
+										},
+									},
+								},
+								Status: &trace.Status{
+									Code:    trace.Status_STATUS_CODE_OK,
+									Message: "Success",
+								},
+								Events: []*trace.Span_Event{
+									{
+										TimeUnixNano: eventTime,
+										Name:         "test_event",
+										Attributes: []*common.KeyValue{
+											{
+												Key: "event.attr",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "event-value"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Serialize the request
+	data := serializeTraceRequest(t, req)
+	
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+	
+	// Get results from regular unmarshaling
+	body1 := io.NopCloser(bytes.NewReader(data))
+	regularResult, err := TranslateTraceRequestFromReader(context.Background(), body1, ri)
+	require.NoError(t, err)
+	
+	// Get results from direct unmarshaling
+	body2 := io.NopCloser(bytes.NewReader(data))
+	directResult, err := TranslateTraceRequestFromReaderDirect(context.Background(), body2, ri)
+	require.NoError(t, err)
+	
+	// Compare results
+	assert.Equal(t, len(regularResult.Batches), len(directResult.Batches), "Batch count mismatch")
+	
+	for i, regularBatch := range regularResult.Batches {
+		directBatch := directResult.Batches[i]
+		assert.Equal(t, regularBatch.Dataset, directBatch.Dataset, "Dataset mismatch")
+		assert.Equal(t, len(regularBatch.Events), len(directBatch.Events), "Event count mismatch")
+		
+		// For each event, compare key attributes
+		for j, regularEvent := range regularBatch.Events {
+			directEvent := directBatch.Events[j]
+			
+			// Check core trace attributes
+			assert.Equal(t, regularEvent.Attributes["trace.trace_id"], directEvent.Attributes["trace.trace_id"], "trace_id mismatch")
+			assert.Equal(t, regularEvent.Attributes["trace.span_id"], directEvent.Attributes["trace.span_id"], "span_id mismatch")
+			assert.Equal(t, regularEvent.Attributes["trace.parent_id"], directEvent.Attributes["trace.parent_id"], "parent_id mismatch")
+			assert.Equal(t, regularEvent.Attributes["name"], directEvent.Attributes["name"], "name mismatch")
+			assert.Equal(t, regularEvent.Attributes["span.kind"], directEvent.Attributes["span.kind"], "span.kind mismatch")
+			assert.Equal(t, regularEvent.SampleRate, directEvent.SampleRate, "sample rate mismatch")
+			
+			// Check timestamps are approximately equal (within 1ms)
+			timeDiff := regularEvent.Timestamp.Sub(directEvent.Timestamp).Abs()
+			assert.Less(t, timeDiff, time.Millisecond, "timestamp difference too large")
+		}
+	}
+}
+
+func TestUnmarshalTraceRequestDirect_WithUnknownFields(t *testing.T) {
+	// Create a serialized message with unknown fields
+	// We'll manually create a protobuf message that includes fields not in the current schema
+	// Field 100 in ExportTraceServiceRequest (unknown field)
+	// Field 50 in ResourceSpans (unknown field)
+	// Field 25 in Span (unknown field)
+
+	// Start with a basic valid request
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{
+			{
+				Resource: &resource.Resource{
+					Attributes: []*common.KeyValue{
+						{
+							Key: "service.name",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+							},
+						},
+					},
+				},
+				ScopeSpans: []*trace.ScopeSpans{
+					{
+						Spans: []*trace.Span{
+							{
+								TraceId:           traceID,
+								SpanId:            spanID,
+								Name:              "test-span",
+								Kind:              trace.Span_SPAN_KIND_SERVER,
+								StartTimeUnixNano: startTime,
+								EndTimeUnixNano:   endTime,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Serialize to get a base message
+	baseData := serializeTraceRequest(t, req)
+
+	// Inject unknown fields into the protobuf message
+	// We'll append some extra fields manually
+	// Field 100 with string value "unknown_field" at the root level
+	unknownField100 := []byte{
+		0xa2, 0x06, // field 100, wire type 2 (length-delimited)
+		0x0d, // length 13
+		'u', 'n', 'k', 'n', 'o', 'w', 'n', '_', 'f', 'i', 'e', 'l', 'd',
+	}
+
+	// Combine the data - insert the unknown field before the existing data
+	data := append(unknownField100, baseData...)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	// The direct unmarshaling should skip unknown fields gracefully
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Batches, 1)
+
+	batch := result.Batches[0]
+	assert.Equal(t, "test-service", batch.Dataset)
+	assert.Len(t, batch.Events, 1)
+
+	event := batch.Events[0]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
+	assert.Equal(t, "test-span", event.Attributes["name"])
+}
+
+
+func TestUnmarshalTraceRequestDirect_WithBytesValue(t *testing.T) {
+	// Test with bytes value type
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{
+					{
+						Key: "service.name",
+						Value: &common.AnyValue{
+							Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+						},
+					},
+					{
+						Key: "bytes_attr",
+						Value: &common.AnyValue{
+							Value: &common.AnyValue_BytesValue{BytesValue: []byte{0x01, 0x02, 0x03, 0x04}},
+						},
+					},
+				},
+			},
+			ScopeSpans: []*trace.ScopeSpans{{
+				Spans: []*trace.Span{{
+					TraceId:           traceID,
+					SpanId:            spanID,
+					Name:              "test-span",
+					Kind:              trace.Span_SPAN_KIND_SERVER,
+					StartTimeUnixNano: startTime,
+					EndTimeUnixNano:   endTime,
+				}},
+			}},
+		}},
+	}
+
+	// Serialize the request
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	// Test with direct unmarshaling
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Batches, 1)
+
+	batch := result.Batches[0]
+	assert.Equal(t, "test-service", batch.Dataset)
+	assert.Len(t, batch.Events, 1)
+
+	event := batch.Events[0]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
+	assert.Equal(t, "test-span", event.Attributes["name"])
+
+	// Check bytes attribute - should be JSON encoded
+	bytesAttr, ok := event.Attributes["bytes_attr"].(string)
+	assert.True(t, ok, "bytes_attr should be a string")
+	assert.Equal(t, "\"AQIDBA==\"\n", bytesAttr) // base64 encoded with JSON encoding and newline
+}
+
+func TestUnmarshalTraceRequestDirect_WithUnsupportedAnyValueTypes(t *testing.T) {
+	// Test with unsupported AnyValue types to ensure our direct unmarshaling now supports them
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*trace.ResourceSpans{{
+			Resource: &resource.Resource{
+				Attributes: []*common.KeyValue{
+					{
+						Key: "service.name",
+						Value: &common.AnyValue{
+							Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+						},
+					},
+					{
+						Key: "bytes_attr",
+						Value: &common.AnyValue{
+							Value: &common.AnyValue_BytesValue{BytesValue: []byte{0x01, 0x02, 0x03, 0x04}},
+						},
+					},
+					{
+						Key: "array_attr",
+						Value: &common.AnyValue{
+							Value: &common.AnyValue_ArrayValue{
+								ArrayValue: &common.ArrayValue{
+									Values: []*common.AnyValue{
+										{Value: &common.AnyValue_StringValue{StringValue: "item1"}},
+										{Value: &common.AnyValue_IntValue{IntValue: 42}},
+										{Value: &common.AnyValue_BoolValue{BoolValue: true}},
+									},
+								},
+							},
+						},
+					},
+					{
+						Key: "kvlist_attr",
+						Value: &common.AnyValue{
+							Value: &common.AnyValue_KvlistValue{
+								KvlistValue: &common.KeyValueList{
+									Values: []*common.KeyValue{
+										{
+											Key: "nested_string",
+											Value: &common.AnyValue{
+												Value: &common.AnyValue_StringValue{StringValue: "nested_value"},
+											},
+										},
+										{
+											Key: "nested_int",
+											Value: &common.AnyValue{
+												Value: &common.AnyValue_IntValue{IntValue: 123},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ScopeSpans: []*trace.ScopeSpans{{
+				Spans: []*trace.Span{{
+					TraceId:           traceID,
+					SpanId:            spanID,
+					Name:              "test-span",
+					Kind:              trace.Span_SPAN_KIND_SERVER,
+					StartTimeUnixNano: startTime,
+					EndTimeUnixNano:   endTime,
+					Attributes: []*common.KeyValue{
+						{
+							Key: "span_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
+							},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+
+	// Serialize the request
+	data := serializeTraceRequest(t, req)
+
+	ri := RequestInfo{
+		ApiKey:      "abc123DEF456ghi789jklm",
+		Dataset:     "test-dataset",
+		ContentType: "application/protobuf",
+	}
+
+	// Test with direct unmarshaling - currently it doesn't support bytes/array/kvlist
+	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Batches, 1)
+
+	batch := result.Batches[0]
+	assert.Equal(t, "test-service", batch.Dataset)
+	assert.Len(t, batch.Events, 1)
+
+	event := batch.Events[0]
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
+	assert.Equal(t, "test-span", event.Attributes["name"])
+	assert.Equal(t, "span_attr_val", event.Attributes["span_attr"])
+
+	// With the new implementation, these should now be supported
+	// Check bytes attribute - should be JSON encoded
+	bytesAttr, ok := event.Attributes["bytes_attr"].(string)
+	assert.True(t, ok, "bytes_attr should be a string")
+	assert.Equal(t, "\"AQIDBA==\"\n", bytesAttr) // base64 encoded with JSON encoding and newline
+
+	// Check array attribute - should be JSON encoded
+	arrayAttr, ok := event.Attributes["array_attr"].(string)
+	assert.True(t, ok, "array_attr should be a string")
+	assert.Equal(t, "[\"item1\",42,true]\n", arrayAttr)
+
+	// Check kvlist attribute - should be flattened
+	assert.Equal(t, "nested_value", event.Attributes["kvlist_attr.nested_string"])
+	assert.Equal(t, int64(123), event.Attributes["kvlist_attr.nested_int"])
+}

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -3,253 +3,185 @@ package otlp
 import (
 	"bytes"
 	"context"
-	"io"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack"
 	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	common "go.opentelemetry.io/proto/otlp/common/v1"
 	resource "go.opentelemetry.io/proto/otlp/resource/v1"
 	trace "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
-func TestUnmarshalTraceRequestDirect_Empty(t *testing.T) {
-	// Create an empty request
-	req := &collectortrace.ExportTraceServiceRequest{}
-	data := serializeTraceRequest(t, req)
+// decodeMessagePackAttributes unmarshals MessagePack data into a map for testing
+func decodeMessagePackAttributes(t testing.TB, data []byte) map[string]any {
+	decoder := msgpack.NewDecoder(bytes.NewReader(data))
+	decoder.UseDecodeInterfaceLoose(true)
 
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, len(data), result.RequestSize)
-	assert.Empty(t, result.Batches)
+	var attrs map[string]any
+	err := decoder.Decode(&attrs)
+	require.NoError(t, err, "Failed to unmarshal MessagePack attributes")
+	return attrs
 }
 
-func TestUnmarshalTraceRequestDirect_WithResourceSpans(t *testing.T) {
-	// Create a request with ResourceSpans but no actual spans
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{
-			{},
-			{},
-		},
-	}
-	data := serializeTraceRequest(t, req)
-
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
+// convertBatchMsgpToBatch converts a BatchMsgp to a Batch by deserializing the msgpack attributes
+func convertBatchMsgpToBatch(t testing.TB, msgpBatch BatchMsgp) Batch {
+	batch := Batch{
+		Dataset: msgpBatch.Dataset,
+		Events:  make([]Event, len(msgpBatch.Events)),
 	}
 
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, len(data), result.RequestSize)
-	// No batches yet since we don't parse spans
-	assert.Empty(t, result.Batches)
+	for i, msgpEvent := range msgpBatch.Events {
+		attrs := decodeMessagePackAttributes(t, msgpEvent.Attributes)
+
+		// Normalize integer types to match what the regular unmarshaling produces
+		normalizeIntegerTypes(attrs)
+
+		batch.Events[i] = Event{
+			Attributes: attrs,
+			Timestamp:  msgpEvent.Timestamp,
+			SampleRate: msgpEvent.SampleRate,
+		}
+	}
+
+	return batch
 }
 
-func TestUnmarshalTraceRequestDirect_WithResource(t *testing.T) {
-	// Create a request with ResourceSpans including resource attributes
+// normalizeIntegerTypes converts integer types to match the regular unmarshaling behavior
+func normalizeIntegerTypes(attrs map[string]any) {
+	for k, v := range attrs {
+		switch val := v.(type) {
+		case int64:
+			// For the special fields, convert to int
+			if k == "status_code" || k == "span.num_events" || k == "span.num_links" {
+				attrs[k] = int(val)
+			}
+		}
+	}
+}
+
+func TestUnmarshalTraceRequestDirect_Complete(t *testing.T) {
+	// Create a comprehensive test request with all supported features
+	traceID1 := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID1 := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	parentSpanID1 := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
+
+	traceID2 := []byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x20}
+	spanID2 := []byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28}
+
+	linkedTraceID := []byte{0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40}
+	linkedSpanID := []byte{0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48}
+
+	startTime := uint64(1234567890123456789)
+	endTime := uint64(1234567890987654321)
+	event1Time := uint64(1234567890123456789 + 100_000_000) // 100ms after start
+	event2Time := uint64(1234567890123456789 + 200_000_000) // 200ms after start
+
+	// For the error span with negative duration
+	errorStartTime := uint64(1234567890987654321)
+	errorEndTime := uint64(1234567890123456789) // end before start
+
 	req := &collectortrace.ExportTraceServiceRequest{
 		ResourceSpans: []*trace.ResourceSpans{
+			// First ResourceSpan - service1 with comprehensive attributes
 			{
 				Resource: &resource.Resource{
 					Attributes: []*common.KeyValue{
 						{
 							Key: "service.name",
 							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+								Value: &common.AnyValue_StringValue{StringValue: "service1"},
 							},
 						},
 						{
-							Key: "resource.attr",
+							Key: "deployment.environment",
 							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "resource-value"},
+								Value: &common.AnyValue_StringValue{StringValue: "production"},
 							},
 						},
-					},
-				},
-			},
-		},
-	}
-	data := serializeTraceRequest(t, req)
-
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	// No batches yet since we don't parse spans
-	assert.Empty(t, result.Batches)
-}
-
-func TestUnmarshalTraceRequestDirect_WithScopeSpans(t *testing.T) {
-	// Create a request with ScopeSpans and InstrumentationScope
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{
-			{
-				Resource: &resource.Resource{
-					Attributes: []*common.KeyValue{
 						{
-							Key: "service.name",
+							Key: "bytes_attr",
 							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
+								Value: &common.AnyValue_BytesValue{BytesValue: []byte{0x01, 0x02, 0x03, 0x04}},
+							},
+						},
+						{
+							Key: "array_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_ArrayValue{
+									ArrayValue: &common.ArrayValue{
+										Values: []*common.AnyValue{
+											{Value: &common.AnyValue_StringValue{StringValue: "item1"}},
+											{Value: &common.AnyValue_IntValue{IntValue: 42}},
+											{Value: &common.AnyValue_BoolValue{BoolValue: true}},
+											{Value: &common.AnyValue_DoubleValue{DoubleValue: 3.14}},
+										},
+									},
+								},
+							},
+						},
+						{
+							Key: "kvlist_attr",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_KvlistValue{
+									KvlistValue: &common.KeyValueList{
+										Values: []*common.KeyValue{
+											{
+												Key: "nested_string",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "nested_value"},
+												},
+											},
+											{
+												Key: "nested_int",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_IntValue{IntValue: 123},
+												},
+											},
+											{
+												Key: "nested_bool",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_BoolValue{BoolValue: false},
+												},
+											},
+											{
+												Key: "nested_double",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_DoubleValue{DoubleValue: 456.789},
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},
 				},
 				ScopeSpans: []*trace.ScopeSpans{
+					// First scope - recognized instrumentation library
 					{
 						Scope: &common.InstrumentationScope{
-							Name:    "test-library",
+							Name:    "go.opentelemetry.io/contrib/instrumentation/net/http",
 							Version: "1.0.0",
 							Attributes: []*common.KeyValue{
 								{
 									Key: "scope.attr",
 									Value: &common.AnyValue{
-										Value: &common.AnyValue_StringValue{StringValue: "scope-value"},
+										Value: &common.AnyValue_StringValue{StringValue: "scope_value"},
 									},
 								},
 							},
 						},
-						// We'll add spans in the next test
-					},
-				},
-			},
-		},
-	}
-	data := serializeTraceRequest(t, req)
-
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	// No batches yet since we don't parse spans
-	assert.Empty(t, result.Batches)
-}
-
-func TestUnmarshalTraceRequestDirect_WithBasicSpan(t *testing.T) {
-	// Create a simple span
-	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	startTime := uint64(1234567890123456789)
-	endTime := uint64(1234567890987654321)
-	// Expected duration: (1234567890987654321 - 1234567890123456789) = 864197532 ns = 864.197532 ms ≈ 864 ms
-
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{
-			{
-				Resource: &resource.Resource{
-					Attributes: []*common.KeyValue{
-						{
-							Key: "service.name",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
-							},
-						},
-					},
-				},
-				ScopeSpans: []*trace.ScopeSpans{
-					{
-						Scope: &common.InstrumentationScope{
-							Name:    "test-library",
-							Version: "1.0.0",
-						},
 						Spans: []*trace.Span{
+							// Span 1: Server span with all features
 							{
-								TraceId:           traceID,
-								SpanId:            spanID,
-								Name:              "test-span",
-								Kind:              trace.Span_SPAN_KIND_CLIENT,
-								StartTimeUnixNano: startTime,
-								EndTimeUnixNano:   endTime,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	data := serializeTraceRequest(t, req)
-
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Len(t, result.Batches, 1)
-	
-	batch := result.Batches[0]
-	assert.Equal(t, "test-service", batch.Dataset)
-	assert.Len(t, batch.Events, 1)
-	
-	event := batch.Events[0]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
-	assert.Equal(t, "test-span", event.Attributes["name"])
-	assert.Equal(t, "client", event.Attributes["span.kind"])
-	assert.InDelta(t, float64(864.197532), event.Attributes["duration_ms"], 0.01)
-	assert.Equal(t, "test-library", event.Attributes["library.name"])
-	assert.Equal(t, "1.0.0", event.Attributes["library.version"])
-	assert.Equal(t, "test-service", event.Attributes["service.name"])
-}
-
-func TestUnmarshalTraceRequestDirect_WithSpanAttributesAndStatus(t *testing.T) {
-	// Create a span with attributes and status
-	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	parentSpanID := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
-	startTime := uint64(1234567890123456789)
-	endTime := uint64(1234567890987654321)
-
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{
-			{
-				Resource: &resource.Resource{
-					Attributes: []*common.KeyValue{
-						{
-							Key: "service.name",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
-							},
-						},
-					},
-				},
-				ScopeSpans: []*trace.ScopeSpans{
-					{
-						Scope: &common.InstrumentationScope{
-							Name:    "test-library",
-							Version: "1.0.0",
-						},
-						Spans: []*trace.Span{
-							{
-								TraceId:           traceID,
-								SpanId:            spanID,
-								ParentSpanId:      parentSpanID,
-								TraceState:        "w3c=true",
-								Name:              "test-span",
+								TraceId:           traceID1,
+								SpanId:            spanID1,
+								ParentSpanId:      parentSpanID1,
+								TraceState:        "w3c=true;th=8",
+								Name:              "HTTP GET /api/users",
 								Kind:              trace.Span_SPAN_KIND_SERVER,
 								StartTimeUnixNano: startTime,
 								EndTimeUnixNano:   endTime,
@@ -269,7 +201,7 @@ func TestUnmarshalTraceRequestDirect_WithSpanAttributesAndStatus(t *testing.T) {
 									{
 										Key: "http.url",
 										Value: &common.AnyValue{
-											Value: &common.AnyValue_StringValue{StringValue: "https://example.com/api/v1/users"},
+											Value: &common.AnyValue_StringValue{StringValue: "https://example.com/api/users"},
 										},
 									},
 									{
@@ -295,95 +227,10 @@ func TestUnmarshalTraceRequestDirect_WithSpanAttributesAndStatus(t *testing.T) {
 									Code:    trace.Status_STATUS_CODE_OK,
 									Message: "Request completed successfully",
 								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	data := serializeTraceRequest(t, req)
-
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Len(t, result.Batches, 1)
-	
-	batch := result.Batches[0]
-	assert.Equal(t, "test-service", batch.Dataset)
-	assert.Len(t, batch.Events, 1)
-	
-	event := batch.Events[0]
-	// Basic fields
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
-	assert.Equal(t, "1112131415161718", event.Attributes["trace.parent_id"])
-	assert.Equal(t, "w3c=true", event.Attributes["trace.trace_state"])
-	assert.Equal(t, "test-span", event.Attributes["name"])
-	assert.Equal(t, "server", event.Attributes["span.kind"])
-	
-	// Span attributes
-	assert.Equal(t, "GET", event.Attributes["http.method"])
-	assert.Equal(t, int64(200), event.Attributes["http.status_code"])
-	assert.Equal(t, "https://example.com/api/v1/users", event.Attributes["http.url"])
-	assert.Equal(t, float64(1234.56), event.Attributes["response.size"])
-	assert.Equal(t, true, event.Attributes["success"])
-	
-	// Status
-	assert.Equal(t, 1, event.Attributes["status_code"]) // STATUS_CODE_OK = 1
-	assert.Equal(t, "Request completed successfully", event.Attributes["status_message"])
-	
-	// Sample rate should be extracted from attributes
-	assert.Equal(t, int32(10), event.SampleRate)
-	// sampleRate attribute should be removed
-	assert.Nil(t, event.Attributes["sampleRate"])
-}
-
-func TestUnmarshalTraceRequestDirect_WithSpanEvents(t *testing.T) {
-	// Create a span with events
-	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	startTime := uint64(1234567890123456789)
-	endTime := uint64(1234567890987654321)
-	event1Time := uint64(1234567890123456789 + 100_000_000) // 100ms after start
-	event2Time := uint64(1234567890123456789 + 200_000_000) // 200ms after start
-
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{
-			{
-				Resource: &resource.Resource{
-					Attributes: []*common.KeyValue{
-						{
-							Key: "service.name",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
-							},
-						},
-					},
-				},
-				ScopeSpans: []*trace.ScopeSpans{
-					{
-						Scope: &common.InstrumentationScope{
-							Name: "test-library",
-						},
-						Spans: []*trace.Span{
-							{
-								TraceId:           traceID,
-								SpanId:            spanID,
-								Name:              "test-span",
-								Kind:              trace.Span_SPAN_KIND_SERVER,
-								StartTimeUnixNano: startTime,
-								EndTimeUnixNano:   endTime,
 								Events: []*trace.Span_Event{
 									{
 										TimeUnixNano: event1Time,
-										Name:         "cache_miss", 
+										Name:         "cache_miss",
 										Attributes: []*common.KeyValue{
 											{
 												Key: "cache.key",
@@ -412,108 +259,29 @@ func TestUnmarshalTraceRequestDirect_WithSpanEvents(t *testing.T) {
 											{
 												Key: "exception.message",
 												Value: &common.AnyValue{
-													Value: &common.AnyValue_StringValue{StringValue: "Invalid input"},
+													Value: &common.AnyValue_StringValue{StringValue: "Invalid user ID"},
+												},
+											},
+											{
+												Key: "exception.stacktrace",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "stack trace here..."},
+												},
+											},
+											{
+												Key: "exception.escaped",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_BoolValue{BoolValue: true},
 												},
 											},
 										},
 									},
 								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	data := serializeTraceRequest(t, req)
-
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Len(t, result.Batches, 1)
-	
-	batch := result.Batches[0]
-	assert.Equal(t, "test-service", batch.Dataset)
-	// Should have 3 events: 1 span + 2 span events
-	assert.Len(t, batch.Events, 3)
-	
-	// First event is the cache_miss event
-	event1 := batch.Events[0]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event1.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", event1.Attributes["trace.parent_id"]) // parent is the span
-	assert.Nil(t, event1.Attributes["trace.span_id"]) // span events don't have their own span ID
-	assert.Equal(t, "cache_miss", event1.Attributes["name"])
-	assert.Equal(t, "span_event", event1.Attributes["meta.annotation_type"])
-	assert.Equal(t, "user:123", event1.Attributes["cache.key"])
-	assert.Equal(t, int64(3600), event1.Attributes["cache.ttl"])
-	assert.Equal(t, float64(100), event1.Attributes["meta.time_since_span_start_ms"]) // relative to span start
-	
-	// Second event is the exception event  
-	event2 := batch.Events[1]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event2.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", event2.Attributes["trace.parent_id"])
-	assert.Nil(t, event2.Attributes["trace.span_id"]) // span events don't have their own span ID
-	assert.Equal(t, "exception", event2.Attributes["name"])
-	assert.Equal(t, "span_event", event2.Attributes["meta.annotation_type"])
-	assert.Equal(t, "ValueError", event2.Attributes["exception.type"])
-	assert.Equal(t, "Invalid input", event2.Attributes["exception.message"])
-	assert.Equal(t, float64(200), event2.Attributes["meta.time_since_span_start_ms"])
-	
-	// Third event is the span itself
-	spanEvent := batch.Events[2]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", spanEvent.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", spanEvent.Attributes["trace.span_id"])
-	assert.Equal(t, "test-span", spanEvent.Attributes["name"])
-}
-
-func TestUnmarshalTraceRequestDirect_WithSpanLinks(t *testing.T) {
-	// Create a span with links
-	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	linkedTraceID1 := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20}
-	linkedSpanID1 := []byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28}
-	linkedTraceID2 := []byte{0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40}
-	linkedSpanID2 := []byte{0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48}
-	startTime := uint64(1234567890123456789)
-	endTime := uint64(1234567890987654321)
-
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{
-			{
-				Resource: &resource.Resource{
-					Attributes: []*common.KeyValue{
-						{
-							Key: "service.name",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
-							},
-						},
-					},
-				},
-				ScopeSpans: []*trace.ScopeSpans{
-					{
-						Scope: &common.InstrumentationScope{
-							Name: "test-library",
-						},
-						Spans: []*trace.Span{
-							{
-								TraceId:           traceID,
-								SpanId:            spanID,
-								Name:              "test-span",
-								Kind:              trace.Span_SPAN_KIND_SERVER,
-								StartTimeUnixNano: startTime,
-								EndTimeUnixNano:   endTime,
 								Links: []*trace.Span_Link{
 									{
-										TraceId:    linkedTraceID1,
-										SpanId:     linkedSpanID1,
-										TraceState: "vendor1=value1",
+										TraceId:    linkedTraceID,
+										SpanId:     linkedSpanID,
+										TraceState: "vendor=value",
 										Attributes: []*common.KeyValue{
 											{
 												Key: "link.type",
@@ -523,21 +291,84 @@ func TestUnmarshalTraceRequestDirect_WithSpanLinks(t *testing.T) {
 											},
 										},
 									},
+								},
+							},
+							// Span 2: Client span
+							{
+								TraceId:           traceID1,
+								SpanId:            spanID2,
+								ParentSpanId:      spanID1,
+								Name:              "DB Query",
+								Kind:              trace.Span_SPAN_KIND_CLIENT,
+								StartTimeUnixNano: startTime + 50_000_000,
+								EndTimeUnixNano:   endTime - 50_000_000,
+								Attributes: []*common.KeyValue{
 									{
-										TraceId:    linkedTraceID2,
-										SpanId:     linkedSpanID2,
-										TraceState: "vendor2=value2",
+										Key: "db.statement",
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_StringValue{StringValue: "SELECT * FROM users WHERE id = ?"},
+										},
+									},
+								},
+								Status: &trace.Status{
+									Code: trace.Status_STATUS_CODE_UNSET,
+								},
+							},
+						},
+					},
+					// Second scope - unrecognized library
+					{
+						Scope: &common.InstrumentationScope{
+							Name:    "custom-library",
+							Version: "2.0.0",
+						},
+						Spans: []*trace.Span{
+							// Span 3: Error span with negative duration
+							{
+								TraceId:           traceID1,
+								SpanId:            []byte{0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38},
+								Name:              "Error Operation",
+								Kind:              trace.Span_SPAN_KIND_INTERNAL,
+								StartTimeUnixNano: errorStartTime,
+								EndTimeUnixNano:   errorEndTime,
+								Status: &trace.Status{
+									Code:    trace.Status_STATUS_CODE_ERROR,
+									Message: "Operation failed",
+								},
+								Events: []*trace.Span_Event{
+									// Multiple exception events - only first should be copied to span
+									{
+										TimeUnixNano: errorStartTime - 100_000_000, // Before span start
+										Name:         "exception",
 										Attributes: []*common.KeyValue{
 											{
-												Key: "link.type",
+												Key: "exception.type",
 												Value: &common.AnyValue{
-													Value: &common.AnyValue_StringValue{StringValue: "child"},
+													Value: &common.AnyValue_StringValue{StringValue: "RuntimeError"},
 												},
 											},
 											{
-												Key: "link.service",
+												Key: "exception.message",
 												Value: &common.AnyValue{
-													Value: &common.AnyValue_StringValue{StringValue: "downstream-service"},
+													Value: &common.AnyValue_StringValue{StringValue: "First exception"},
+												},
+											},
+										},
+									},
+									{
+										TimeUnixNano: errorStartTime + 100_000_000,
+										Name:         "exception",
+										Attributes: []*common.KeyValue{
+											{
+												Key: "exception.type",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "IOError"},
+												},
+											},
+											{
+												Key: "exception.message",
+												Value: &common.AnyValue{
+													Value: &common.AnyValue_StringValue{StringValue: "Second exception"},
 												},
 											},
 										},
@@ -548,138 +379,29 @@ func TestUnmarshalTraceRequestDirect_WithSpanLinks(t *testing.T) {
 					},
 				},
 			},
-		},
-	}
-	data := serializeTraceRequest(t, req)
-
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Len(t, result.Batches, 1)
-	
-	batch := result.Batches[0]
-	assert.Equal(t, "test-service", batch.Dataset)
-	// Should have 3 events: 1 span + 2 span links
-	assert.Len(t, batch.Events, 3)
-	
-	// First event is the first link
-	link1 := batch.Events[0]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", link1.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", link1.Attributes["trace.parent_id"]) // parent is the span
-	assert.Nil(t, link1.Attributes["trace.span_id"]) // span links don't have their own span ID
-	assert.Equal(t, "1112131415161718191a1b1c1d1e1f20", link1.Attributes["trace.link.trace_id"])
-	assert.Equal(t, "2122232425262728", link1.Attributes["trace.link.span_id"])
-	// trace.link.trace_state is not added by the implementation
-	assert.Equal(t, "link", link1.Attributes["meta.annotation_type"])
-	assert.Equal(t, "parent", link1.Attributes["link.type"])
-	
-	// Second event is the second link  
-	link2 := batch.Events[1]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", link2.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", link2.Attributes["trace.parent_id"])
-	assert.Nil(t, link2.Attributes["trace.span_id"]) // span links don't have their own span ID
-	assert.Equal(t, "3132333435363738393a3b3c3d3e3f40", link2.Attributes["trace.link.trace_id"])
-	assert.Equal(t, "4142434445464748", link2.Attributes["trace.link.span_id"])
-	// trace.link.trace_state is not added by the implementation
-	assert.Equal(t, "link", link2.Attributes["meta.annotation_type"])
-	assert.Equal(t, "child", link2.Attributes["link.type"])
-	assert.Equal(t, "downstream-service", link2.Attributes["link.service"])
-	
-	// Third event is the span itself
-	spanEvent := batch.Events[2]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", spanEvent.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", spanEvent.Attributes["trace.span_id"])
-	assert.Equal(t, "test-span", spanEvent.Attributes["name"])
-}
-
-func TestTranslateTraceRequestFromReaderDirect(t *testing.T) {
-	// Create a test request with all features we support
-	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	parentSpanID := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
-	startTime := uint64(1234567890123456789)
-	endTime := uint64(1234567890987654321)
-	eventTime := uint64(1234567890123456789 + 100_000_000) // 100ms after start
-
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{
+			// Second ResourceSpan - service2
 			{
 				Resource: &resource.Resource{
 					Attributes: []*common.KeyValue{
 						{
 							Key: "service.name",
 							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
-							},
-						},
-						{
-							Key: "deployment.environment", 
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "production"},
+								Value: &common.AnyValue_StringValue{StringValue: "service2"},
 							},
 						},
 					},
 				},
 				ScopeSpans: []*trace.ScopeSpans{
 					{
-						Scope: &common.InstrumentationScope{
-							Name:    "test-library",
-							Version: "1.0.0",
-						},
 						Spans: []*trace.Span{
+							// Span 4: Producer span
 							{
-								TraceId:           traceID,
-								SpanId:            spanID,
-								ParentSpanId:      parentSpanID,
-								TraceState:        "w3c=true",
-								Name:              "HTTP GET /api/users",
-								Kind:              trace.Span_SPAN_KIND_SERVER,
+								TraceId:           traceID2,
+								SpanId:            spanID2,
+								Name:              "Publish Message",
+								Kind:              trace.Span_SPAN_KIND_PRODUCER,
 								StartTimeUnixNano: startTime,
 								EndTimeUnixNano:   endTime,
-								Attributes: []*common.KeyValue{
-									{
-										Key: "http.method",
-										Value: &common.AnyValue{
-											Value: &common.AnyValue_StringValue{StringValue: "GET"},
-										},
-									},
-									{
-										Key: "http.status_code",
-										Value: &common.AnyValue{
-											Value: &common.AnyValue_IntValue{IntValue: 200},
-										},
-									},
-									{
-										Key: "sampleRate",
-										Value: &common.AnyValue{
-											Value: &common.AnyValue_IntValue{IntValue: 10},
-										},
-									},
-								},
-								Status: &trace.Status{
-									Code:    trace.Status_STATUS_CODE_OK,
-									Message: "Success",
-								},
-								Events: []*trace.Span_Event{
-									{
-										TimeUnixNano: eventTime,
-										Name:         "db_query",
-										Attributes: []*common.KeyValue{
-											{
-												Key: "db.statement",
-												Value: &common.AnyValue{
-													Value: &common.AnyValue_StringValue{StringValue: "SELECT * FROM users"},
-												},
-											},
-										},
-									},
-								},
 							},
 						},
 					},
@@ -688,193 +410,289 @@ func TestTranslateTraceRequestFromReaderDirect(t *testing.T) {
 		},
 	}
 
-	// Serialize the request
 	data := serializeTraceRequest(t, req)
-	
-	// Create a reader from the data
-	body := io.NopCloser(bytes.NewReader(data))
-	
-	// Create request info
+
 	ri := RequestInfo{
 		ApiKey:      "abc123DEF456ghi789jklm",
 		Dataset:     "test-dataset",
 		ContentType: "application/protobuf",
 	}
-	
-	// Call the new direct function
-	result, err := TranslateTraceRequestFromReaderDirect(context.Background(), body, ri)
+
+	result, err := UnmarshalTraceRequestDirectMsgp(context.Background(), data, ri)
 	require.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Greater(t, result.RequestSize, 0)
-	assert.Len(t, result.Batches, 1)
-	
-	batch := result.Batches[0]
-	assert.Equal(t, "test-service", batch.Dataset)
-	// Should have 2 events: 1 span + 1 span event
-	assert.Len(t, batch.Events, 2)
-	
-	// First event should be the span event (db_query)
-	dbEvent := batch.Events[0]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", dbEvent.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", dbEvent.Attributes["trace.parent_id"])
-	assert.Nil(t, dbEvent.Attributes["trace.span_id"]) // span events don't have their own span ID
-	assert.Equal(t, "db_query", dbEvent.Attributes["name"])
-	assert.Equal(t, "span_event", dbEvent.Attributes["meta.annotation_type"])
-	assert.Equal(t, "SELECT * FROM users", dbEvent.Attributes["db.statement"])
-	assert.Equal(t, float64(100), dbEvent.Attributes["meta.time_since_span_start_ms"])
-	assert.Equal(t, int32(10), dbEvent.SampleRate)
-	
-	// Second event should be the main span
-	spanEvent := batch.Events[1]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", spanEvent.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", spanEvent.Attributes["trace.span_id"])
-	assert.Equal(t, "1112131415161718", spanEvent.Attributes["trace.parent_id"])
-	assert.Equal(t, "HTTP GET /api/users", spanEvent.Attributes["name"])
-	assert.Equal(t, "server", spanEvent.Attributes["span.kind"])
-	assert.Equal(t, "GET", spanEvent.Attributes["http.method"])
-	assert.Equal(t, int64(200), spanEvent.Attributes["http.status_code"])
-	assert.Equal(t, 1, spanEvent.Attributes["status_code"]) // STATUS_CODE_OK = 1
-	assert.Equal(t, "Success", spanEvent.Attributes["status_message"])
-	assert.Equal(t, int32(10), spanEvent.SampleRate)
-	assert.Equal(t, "production", spanEvent.Attributes["deployment.environment"])
-}
+	assert.Equal(t, len(data), result.RequestSize)
+	assert.Len(t, result.Batches, 2) // Two different services
 
-func TestCompareDirectVsRegularUnmarshaling(t *testing.T) {
-	// Create a complex test request
-	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	parentSpanID := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
-	startTime := uint64(1234567890123456789)
-	endTime := uint64(1234567890987654321)
-	eventTime := uint64(1234567890123456789 + 100_000_000)
+	// Batch 1: service1
+	batch1 := result.Batches[0]
+	assert.Equal(t, "service1", batch1.Dataset)
+	// 3 spans + 2 events from span1 + 2 events from error span + 1 link = 8 events
+	assert.Len(t, batch1.Events, 8)
 
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{
-			{
-				Resource: &resource.Resource{
-					Attributes: []*common.KeyValue{
-						{
-							Key: "service.name",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "test-service"},
-							},
-						},
-						{
-							Key: "resource.attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "resource-value"},
-							},
-						},
-					},
-				},
-				ScopeSpans: []*trace.ScopeSpans{
-					{
-						Scope: &common.InstrumentationScope{
-							Name:    "test-library",
-							Version: "1.0.0",
-							Attributes: []*common.KeyValue{
-								{
-									Key: "scope.attr",
-									Value: &common.AnyValue{
-										Value: &common.AnyValue_StringValue{StringValue: "scope-value"},
-									},
-								},
-							},
-						},
-						Spans: []*trace.Span{
-							{
-								TraceId:           traceID,
-								SpanId:            spanID,
-								ParentSpanId:      parentSpanID,
-								TraceState:        "w3c=true",
-								Name:              "test-span",
-								Kind:              trace.Span_SPAN_KIND_SERVER,
-								StartTimeUnixNano: startTime,
-								EndTimeUnixNano:   endTime,
-								Attributes: []*common.KeyValue{
-									{
-										Key: "http.method",
-										Value: &common.AnyValue{
-											Value: &common.AnyValue_StringValue{StringValue: "GET"},
-										},
-									},
-									{
-										Key: "sampleRate",
-										Value: &common.AnyValue{
-											Value: &common.AnyValue_IntValue{IntValue: 10},
-										},
-									},
-								},
-								Status: &trace.Status{
-									Code:    trace.Status_STATUS_CODE_OK,
-									Message: "Success",
-								},
-								Events: []*trace.Span_Event{
-									{
-										TimeUnixNano: eventTime,
-										Name:         "test_event",
-										Attributes: []*common.KeyValue{
-											{
-												Key: "event.attr",
-												Value: &common.AnyValue{
-													Value: &common.AnyValue_StringValue{StringValue: "event-value"},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	// Events are in deterministic order:
+	// 0: cache_miss event (from span1)
+	// 1: exception event (from span1)
+	// 2: link (from span1)
+	// 3: HTTP GET /api/users span (span1 itself)
+	// 4: DB Query span (span2)
+	// 5: First exception event (from error span)
+	// 6: Second exception event (from error span)
+	// 7: Error Operation span (error span itself)
 
-	// Serialize the request
-	data := serializeTraceRequest(t, req)
-	
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-	
-	// Get results from regular unmarshaling
-	body1 := io.NopCloser(bytes.NewReader(data))
-	regularResult, err := TranslateTraceRequestFromReader(context.Background(), body1, ri)
-	require.NoError(t, err)
-	
-	// Get results from direct unmarshaling
-	body2 := io.NopCloser(bytes.NewReader(data))
-	directResult, err := TranslateTraceRequestFromReaderDirect(context.Background(), body2, ri)
-	require.NoError(t, err)
-	
-	// Compare results
-	assert.Equal(t, len(regularResult.Batches), len(directResult.Batches), "Batch count mismatch")
-	
-	for i, regularBatch := range regularResult.Batches {
-		directBatch := directResult.Batches[i]
-		assert.Equal(t, regularBatch.Dataset, directBatch.Dataset, "Dataset mismatch")
-		assert.Equal(t, len(regularBatch.Events), len(directBatch.Events), "Event count mismatch")
-		
-		// For each event, compare key attributes
-		for j, regularEvent := range regularBatch.Events {
-			directEvent := directBatch.Events[j]
-			
-			// Check core trace attributes
-			assert.Equal(t, regularEvent.Attributes["trace.trace_id"], directEvent.Attributes["trace.trace_id"], "trace_id mismatch")
-			assert.Equal(t, regularEvent.Attributes["trace.span_id"], directEvent.Attributes["trace.span_id"], "span_id mismatch")
-			assert.Equal(t, regularEvent.Attributes["trace.parent_id"], directEvent.Attributes["trace.parent_id"], "parent_id mismatch")
-			assert.Equal(t, regularEvent.Attributes["name"], directEvent.Attributes["name"], "name mismatch")
-			assert.Equal(t, regularEvent.Attributes["span.kind"], directEvent.Attributes["span.kind"], "span.kind mismatch")
-			assert.Equal(t, regularEvent.SampleRate, directEvent.SampleRate, "sample rate mismatch")
-			
-			// Check timestamps are approximately equal (within 1ms)
-			timeDiff := regularEvent.Timestamp.Sub(directEvent.Timestamp).Abs()
-			assert.Less(t, timeDiff, time.Millisecond, "timestamp difference too large")
+	// Verify the main span (HTTP GET /api/users) at index 3
+	mainSpan := &batch1.Events[3]
+
+	mainAttrs := decodeMessagePackAttributes(t, mainSpan.Attributes)
+
+	// Core attributes
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", mainAttrs["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", mainAttrs["trace.span_id"])
+	assert.Equal(t, "1112131415161718", mainAttrs["trace.parent_id"])
+	assert.Equal(t, "w3c=true;th=8", mainAttrs["trace.trace_state"])
+	assert.Equal(t, "HTTP GET /api/users", mainAttrs["name"])
+	assert.Equal(t, "server", mainAttrs["span.kind"])
+	assert.Equal(t, "server", mainAttrs["type"])
+
+	// Resource attributes
+	assert.Equal(t, "service1", mainAttrs["service.name"])
+	assert.Equal(t, "production", mainAttrs["deployment.environment"])
+	assert.Equal(t, "\"AQIDBA==\"\n", mainAttrs["bytes_attr"])
+	assert.Equal(t, "[\"item1\",42,true,3.14]\n", mainAttrs["array_attr"])
+
+	// Flattened kvlist attributes
+	assert.Equal(t, "nested_value", mainAttrs["kvlist_attr.nested_string"])
+	assert.Equal(t, int64(123), mainAttrs["kvlist_attr.nested_int"])
+	assert.Equal(t, false, mainAttrs["kvlist_attr.nested_bool"])
+	assert.Equal(t, float64(456.789), mainAttrs["kvlist_attr.nested_double"])
+
+	// Scope attributes
+	assert.Equal(t, "go.opentelemetry.io/contrib/instrumentation/net/http", mainAttrs["library.name"])
+	assert.Equal(t, "1.0.0", mainAttrs["library.version"])
+	assert.Equal(t, true, mainAttrs["telemetry.instrumentation_library"])
+	assert.Equal(t, "scope_value", mainAttrs["scope.attr"])
+
+	// Span attributes
+	assert.Equal(t, "GET", mainAttrs["http.method"])
+	assert.Equal(t, int64(200), mainAttrs["http.status_code"])
+	assert.Equal(t, "https://example.com/api/users", mainAttrs["http.url"])
+	assert.Equal(t, float64(1234.56), mainAttrs["response.size"])
+	assert.Equal(t, true, mainAttrs["success"])
+
+	// Status
+	assert.Equal(t, int64(1), mainAttrs["status_code"]) // STATUS_CODE_OK = 1
+	// Note: traces_direct.go doesn't add status.code or status.message fields
+	assert.Equal(t, "Request completed successfully", mainAttrs["status_message"])
+
+	// Duration
+	assert.InDelta(t, float64(864.197532), mainAttrs["duration_ms"], 0.01)
+
+	// Span event/link counts
+	assert.Equal(t, int64(2), mainAttrs["span.num_events"])
+	assert.Equal(t, int64(1), mainAttrs["span.num_links"])
+
+	// Meta attributes
+	assert.Equal(t, "trace", mainAttrs["meta.signal_type"])
+
+	// Exception attributes (should be copied from first exception event)
+	assert.Equal(t, "ValueError", mainAttrs["exception.type"])
+	assert.Equal(t, "Invalid user ID", mainAttrs["exception.message"])
+	assert.Equal(t, "stack trace here...", mainAttrs["exception.stacktrace"])
+	assert.Equal(t, true, mainAttrs["exception.escaped"])
+
+	// Sample rate and timestamp
+	assert.Equal(t, int32(10), mainSpan.SampleRate)
+	assert.Nil(t, mainAttrs["sampleRate"]) // Should be removed
+	assert.Equal(t, time.Unix(0, int64(startTime)).UTC(), mainSpan.Timestamp)
+
+	// Verify span events
+	cacheEvent := &batch1.Events[0]
+	cacheAttrs := decodeMessagePackAttributes(t, cacheEvent.Attributes)
+	assert.Equal(t, "cache_miss", cacheAttrs["name"])
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", cacheAttrs["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", cacheAttrs["trace.parent_id"])
+	assert.Equal(t, "HTTP GET /api/users", cacheAttrs["parent_name"])
+	assert.Equal(t, "user:123", cacheAttrs["cache.key"])
+	assert.Equal(t, int64(3600), cacheAttrs["cache.ttl"])
+	assert.Equal(t, float64(100), cacheAttrs["meta.time_since_span_start_ms"])
+	assert.Equal(t, "span_event", cacheAttrs["meta.annotation_type"])
+	assert.Nil(t, cacheAttrs["error"]) // Parent span is not error
+	assert.Equal(t, int32(10), cacheEvent.SampleRate)
+	assert.Equal(t, time.Unix(0, int64(event1Time)).UTC(), cacheEvent.Timestamp)
+
+	// Exception event at index 1
+	exceptionEvent := &batch1.Events[1]
+	exceptionAttrs := decodeMessagePackAttributes(t, exceptionEvent.Attributes)
+	assert.Equal(t, "exception", exceptionAttrs["name"])
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", exceptionAttrs["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", exceptionAttrs["trace.parent_id"])
+	assert.Equal(t, "span_event", exceptionAttrs["meta.annotation_type"])
+	assert.Equal(t, int32(10), exceptionEvent.SampleRate)
+	assert.Equal(t, time.Unix(0, int64(event2Time)).UTC(), exceptionEvent.Timestamp)
+
+	// Link at index 2
+	linkEvent := &batch1.Events[2]
+	linkAttrs := decodeMessagePackAttributes(t, linkEvent.Attributes)
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", linkAttrs["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", linkAttrs["trace.parent_id"])
+	assert.Equal(t, "3132333435363738393a3b3c3d3e3f40", linkAttrs["trace.link.trace_id"])
+	assert.Equal(t, "4142434445464748", linkAttrs["trace.link.span_id"])
+	assert.Equal(t, "parent", linkAttrs["link.type"])
+	assert.Equal(t, "link", linkAttrs["meta.annotation_type"])
+	assert.Equal(t, int32(10), linkEvent.SampleRate)
+	assert.Equal(t, time.Unix(0, int64(startTime)).UTC(), linkEvent.Timestamp) // Links use parent span timestamp
+
+	// DB Query span at index 4
+	dbSpan := &batch1.Events[4]
+	dbAttrs := decodeMessagePackAttributes(t, dbSpan.Attributes)
+	assert.Equal(t, "DB Query", dbAttrs["name"])
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", dbAttrs["trace.trace_id"])
+	assert.Equal(t, "2122232425262728", dbAttrs["trace.span_id"])
+	assert.Equal(t, "0102030405060708", dbAttrs["trace.parent_id"])
+	assert.Equal(t, "client", dbAttrs["span.kind"])
+	assert.Equal(t, "SELECT * FROM users WHERE id = ?", dbAttrs["db.statement"])
+	assert.Equal(t, int32(1), dbSpan.SampleRate) // DB Query span has no explicit sampleRate, gets default
+	assert.Equal(t, time.Unix(0, int64(startTime+50_000_000)).UTC(), dbSpan.Timestamp)
+
+	// Error span at index 7
+	errorSpan := &batch1.Events[7]
+	errorAttrs := decodeMessagePackAttributes(t, errorSpan.Attributes)
+	assert.Equal(t, "Error Operation", errorAttrs["name"])
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", errorAttrs["trace.trace_id"])
+	assert.Equal(t, "3132333435363738", errorAttrs["trace.span_id"])
+	assert.Equal(t, true, errorAttrs["error"])
+	assert.Equal(t, int64(2), errorAttrs["status_code"]) // STATUS_CODE_ERROR = 2
+	assert.Equal(t, "Operation failed", errorAttrs["status_message"])
+	// Note: traces_direct.go doesn't add status.code field
+	// Verify negative duration is handled correctly
+	assert.Equal(t, float64(0), errorAttrs["duration_ms"]) // Negative duration should be clamped to 0
+	assert.Equal(t, true, errorAttrs["meta.invalid_duration"])
+	// Only first exception should be copied
+	assert.Equal(t, "RuntimeError", errorAttrs["exception.type"])
+	assert.Equal(t, "First exception", errorAttrs["exception.message"])
+	assert.Equal(t, int32(1), errorSpan.SampleRate) // Default sample rate
+	assert.Equal(t, time.Unix(0, int64(errorStartTime)).UTC(), errorSpan.Timestamp)
+
+	// Error span's exception events at indices 5 and 6
+	firstExceptionEvent := &batch1.Events[5]
+	firstExceptionAttrs := decodeMessagePackAttributes(t, firstExceptionEvent.Attributes)
+	assert.Equal(t, "exception", firstExceptionAttrs["name"])
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", firstExceptionAttrs["trace.trace_id"])
+	assert.Equal(t, "3132333435363738", firstExceptionAttrs["trace.parent_id"])
+	assert.Equal(t, "Error Operation", firstExceptionAttrs["parent_name"])
+	assert.Equal(t, "RuntimeError", firstExceptionAttrs["exception.type"])
+	assert.Equal(t, "First exception", firstExceptionAttrs["exception.message"])
+	assert.Equal(t, true, firstExceptionAttrs["error"]) // Parent span is error
+	assert.Equal(t, "span_event", firstExceptionAttrs["meta.annotation_type"])
+	// Verify time since span start calculation handles negative values correctly
+	assert.Equal(t, float64(0), firstExceptionAttrs["meta.time_since_span_start_ms"])
+	assert.Equal(t, true, firstExceptionAttrs["meta.invalid_time_since_span_start"])
+	assert.Equal(t, int32(1), firstExceptionEvent.SampleRate)
+	assert.Equal(t, time.Unix(0, int64(errorStartTime-100_000_000)).UTC(), firstExceptionEvent.Timestamp)
+
+	// Second exception event at index 6 (only first exception was copied to error span)
+	secondExceptionEvent := &batch1.Events[6]
+	secondExceptionAttrs := decodeMessagePackAttributes(t, secondExceptionEvent.Attributes)
+	assert.Equal(t, "exception", secondExceptionAttrs["name"])
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", secondExceptionAttrs["trace.trace_id"])
+	assert.Equal(t, "3132333435363738", secondExceptionAttrs["trace.parent_id"])
+	assert.Equal(t, "Error Operation", secondExceptionAttrs["parent_name"])
+	assert.Equal(t, "IOError", secondExceptionAttrs["exception.type"])
+	assert.Equal(t, "Second exception", secondExceptionAttrs["exception.message"])
+	assert.Equal(t, true, secondExceptionAttrs["error"]) // Parent span is error
+	assert.Equal(t, "span_event", secondExceptionAttrs["meta.annotation_type"])
+	assert.Equal(t, float64(100), secondExceptionAttrs["meta.time_since_span_start_ms"])
+	assert.Equal(t, int32(1), secondExceptionEvent.SampleRate)
+	assert.Equal(t, time.Unix(0, int64(errorStartTime+100_000_000)).UTC(), secondExceptionEvent.Timestamp)
+
+	// Batch 2: service2
+	batch2 := result.Batches[1]
+	assert.Equal(t, "service2", batch2.Dataset)
+	assert.Len(t, batch2.Events, 1) // Just the producer span
+
+	producerEvent := batch2.Events[0]
+	producerAttrs := decodeMessagePackAttributes(t, producerEvent.Attributes)
+	assert.Equal(t, "2122232425262728292a2b2c2d2e2f20", producerAttrs["trace.trace_id"])
+	assert.Equal(t, "2122232425262728", producerAttrs["trace.span_id"])
+	assert.Equal(t, "Publish Message", producerAttrs["name"])
+	assert.Equal(t, "producer", producerAttrs["span.kind"])
+	assert.Equal(t, "producer", producerAttrs["type"])
+	assert.Nil(t, producerAttrs["telemetry.instrumentation_library"]) // No recognized library
+	assert.Equal(t, int32(1), producerEvent.SampleRate)               // Default sample rate
+	assert.Equal(t, time.Unix(0, int64(startTime)).UTC(), producerEvent.Timestamp)
+
+	// Now compare with the regular (non-direct) unmarshaling to ensure consistency
+	t.Run("CompareWithRegularUnmarshaling", func(t *testing.T) {
+		// Use the same serialized data with the regular unmarshaling path
+		regularResult, err := TranslateTraceRequest(context.Background(), req, ri)
+		require.NoError(t, err)
+		assert.NotNil(t, regularResult)
+
+		// TODO: Fix these bugs in the regular unmarshaling (traces.go):
+		// 1. Negative duration calculation causes unsigned integer overflow
+		//    - When endTime < startTime, should set duration_ms=0 and meta.invalid_duration=true
+		//    - Currently produces huge positive values like 1.8446744072845355e+13
+		// 2. Negative time_since_span_start calculation causes unsigned integer overflow
+		//    - When event time < span start time, should set time=0 and meta.invalid_time_since_span_start=true
+		//    - Currently produces huge positive values like 1.844674407360955e+13
+
+		// Compare high-level structure
+		assert.Equal(t, result.RequestSize, regularResult.RequestSize)
+		assert.Equal(t, len(result.Batches), len(regularResult.Batches))
+
+		// Convert msgpack batches to regular batches for comparison
+		directBatches := make([]Batch, len(result.Batches))
+		for i, msgpBatch := range result.Batches {
+			directBatches[i] = convertBatchMsgpToBatch(t, msgpBatch)
 		}
-	}
+
+		// Compare each batch
+		for i := range directBatches {
+			directBatch := directBatches[i]
+			regularBatch := regularResult.Batches[i]
+
+			assert.Equal(t, directBatch.Dataset, regularBatch.Dataset, "Batch %d dataset mismatch", i)
+			assert.Equal(t, len(directBatch.Events), len(regularBatch.Events), "Batch %d event count mismatch", i)
+
+			// Compare each event
+			for j := range directBatch.Events {
+				directEvent := directBatch.Events[j]
+				regularEvent := regularBatch.Events[j]
+
+				// Compare timestamps and sample rates
+				assert.Equal(t, directEvent.Timestamp, regularEvent.Timestamp, "Batch %d Event %d timestamp mismatch", i, j)
+				assert.Equal(t, directEvent.SampleRate, regularEvent.SampleRate, "Batch %d Event %d sample rate mismatch", i, j)
+
+				// Compare attributes
+				// Check for known discrepancies that are actually improvements in the direct implementation
+				if i == 0 && j == 5 { // First exception event
+					// The direct implementation correctly handles negative time_since_span_start
+					// Regular: meta.time_since_span_start_ms = 1.844674407360955e+13 (overflow)
+					// Direct: meta.time_since_span_start_ms = 0 + meta.invalid_time_since_span_start = true
+					assert.Equal(t, float64(0), directEvent.Attributes["meta.time_since_span_start_ms"])
+					assert.Equal(t, true, directEvent.Attributes["meta.invalid_time_since_span_start"])
+					// Remove the fields that differ to check the rest
+					delete(regularEvent.Attributes, "meta.time_since_span_start_ms")
+					delete(directEvent.Attributes, "meta.time_since_span_start_ms")
+					delete(directEvent.Attributes, "meta.invalid_time_since_span_start")
+				}
+				if i == 0 && j == 7 { // Error span with negative duration
+					// The direct implementation correctly handles negative duration
+					// Regular: duration_ms = 1.8446744072845355e+13 (overflow)
+					// Direct: duration_ms = 0 + meta.invalid_duration = true
+					assert.Equal(t, float64(0), directEvent.Attributes["duration_ms"])
+					assert.Equal(t, true, directEvent.Attributes["meta.invalid_duration"])
+					// Remove the fields that differ to check the rest
+					delete(regularEvent.Attributes, "duration_ms")
+					delete(directEvent.Attributes, "duration_ms")
+					delete(directEvent.Attributes, "meta.invalid_duration")
+				}
+
+				// Now compare the remaining attributes
+				assert.Equal(t, regularEvent.Attributes, directEvent.Attributes, "Batch %d Event %d attributes mismatch (after removing known improvements)", i, j)
+			}
+		}
+	})
 }
 
 func TestUnmarshalTraceRequestDirect_WithUnknownFields(t *testing.T) {
@@ -943,7 +761,7 @@ func TestUnmarshalTraceRequestDirect_WithUnknownFields(t *testing.T) {
 	}
 
 	// The direct unmarshaling should skip unknown fields gracefully
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
+	result, err := UnmarshalTraceRequestDirectMsgp(context.Background(), data, ri)
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.Batches, 1)
@@ -953,200 +771,8 @@ func TestUnmarshalTraceRequestDirect_WithUnknownFields(t *testing.T) {
 	assert.Len(t, batch.Events, 1)
 
 	event := batch.Events[0]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
-	assert.Equal(t, "test-span", event.Attributes["name"])
-}
-
-
-func TestUnmarshalTraceRequestDirect_WithBytesValue(t *testing.T) {
-	// Test with bytes value type
-	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	startTime := uint64(1234567890123456789)
-	endTime := uint64(1234567890987654321)
-
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{{
-			Resource: &resource.Resource{
-				Attributes: []*common.KeyValue{
-					{
-						Key: "service.name",
-						Value: &common.AnyValue{
-							Value: &common.AnyValue_StringValue{StringValue: "test-service"},
-						},
-					},
-					{
-						Key: "bytes_attr",
-						Value: &common.AnyValue{
-							Value: &common.AnyValue_BytesValue{BytesValue: []byte{0x01, 0x02, 0x03, 0x04}},
-						},
-					},
-				},
-			},
-			ScopeSpans: []*trace.ScopeSpans{{
-				Spans: []*trace.Span{{
-					TraceId:           traceID,
-					SpanId:            spanID,
-					Name:              "test-span",
-					Kind:              trace.Span_SPAN_KIND_SERVER,
-					StartTimeUnixNano: startTime,
-					EndTimeUnixNano:   endTime,
-				}},
-			}},
-		}},
-	}
-
-	// Serialize the request
-	data := serializeTraceRequest(t, req)
-
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	// Test with direct unmarshaling
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Len(t, result.Batches, 1)
-
-	batch := result.Batches[0]
-	assert.Equal(t, "test-service", batch.Dataset)
-	assert.Len(t, batch.Events, 1)
-
-	event := batch.Events[0]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
-	assert.Equal(t, "test-span", event.Attributes["name"])
-
-	// Check bytes attribute - should be JSON encoded
-	bytesAttr, ok := event.Attributes["bytes_attr"].(string)
-	assert.True(t, ok, "bytes_attr should be a string")
-	assert.Equal(t, "\"AQIDBA==\"\n", bytesAttr) // base64 encoded with JSON encoding and newline
-}
-
-func TestUnmarshalTraceRequestDirect_WithUnsupportedAnyValueTypes(t *testing.T) {
-	// Test with unsupported AnyValue types to ensure our direct unmarshaling now supports them
-	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-	spanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	startTime := uint64(1234567890123456789)
-	endTime := uint64(1234567890987654321)
-
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*trace.ResourceSpans{{
-			Resource: &resource.Resource{
-				Attributes: []*common.KeyValue{
-					{
-						Key: "service.name",
-						Value: &common.AnyValue{
-							Value: &common.AnyValue_StringValue{StringValue: "test-service"},
-						},
-					},
-					{
-						Key: "bytes_attr",
-						Value: &common.AnyValue{
-							Value: &common.AnyValue_BytesValue{BytesValue: []byte{0x01, 0x02, 0x03, 0x04}},
-						},
-					},
-					{
-						Key: "array_attr",
-						Value: &common.AnyValue{
-							Value: &common.AnyValue_ArrayValue{
-								ArrayValue: &common.ArrayValue{
-									Values: []*common.AnyValue{
-										{Value: &common.AnyValue_StringValue{StringValue: "item1"}},
-										{Value: &common.AnyValue_IntValue{IntValue: 42}},
-										{Value: &common.AnyValue_BoolValue{BoolValue: true}},
-									},
-								},
-							},
-						},
-					},
-					{
-						Key: "kvlist_attr",
-						Value: &common.AnyValue{
-							Value: &common.AnyValue_KvlistValue{
-								KvlistValue: &common.KeyValueList{
-									Values: []*common.KeyValue{
-										{
-											Key: "nested_string",
-											Value: &common.AnyValue{
-												Value: &common.AnyValue_StringValue{StringValue: "nested_value"},
-											},
-										},
-										{
-											Key: "nested_int",
-											Value: &common.AnyValue{
-												Value: &common.AnyValue_IntValue{IntValue: 123},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			ScopeSpans: []*trace.ScopeSpans{{
-				Spans: []*trace.Span{{
-					TraceId:           traceID,
-					SpanId:            spanID,
-					Name:              "test-span",
-					Kind:              trace.Span_SPAN_KIND_SERVER,
-					StartTimeUnixNano: startTime,
-					EndTimeUnixNano:   endTime,
-					Attributes: []*common.KeyValue{
-						{
-							Key: "span_attr",
-							Value: &common.AnyValue{
-								Value: &common.AnyValue_StringValue{StringValue: "span_attr_val"},
-							},
-						},
-					},
-				}},
-			}},
-		}},
-	}
-
-	// Serialize the request
-	data := serializeTraceRequest(t, req)
-
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "test-dataset",
-		ContentType: "application/protobuf",
-	}
-
-	// Test with direct unmarshaling - currently it doesn't support bytes/array/kvlist
-	result, err := UnmarshalTraceRequestDirect(context.Background(), data, ri)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Len(t, result.Batches, 1)
-
-	batch := result.Batches[0]
-	assert.Equal(t, "test-service", batch.Dataset)
-	assert.Len(t, batch.Events, 1)
-
-	event := batch.Events[0]
-	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", event.Attributes["trace.trace_id"])
-	assert.Equal(t, "0102030405060708", event.Attributes["trace.span_id"])
-	assert.Equal(t, "test-span", event.Attributes["name"])
-	assert.Equal(t, "span_attr_val", event.Attributes["span_attr"])
-
-	// With the new implementation, these should now be supported
-	// Check bytes attribute - should be JSON encoded
-	bytesAttr, ok := event.Attributes["bytes_attr"].(string)
-	assert.True(t, ok, "bytes_attr should be a string")
-	assert.Equal(t, "\"AQIDBA==\"\n", bytesAttr) // base64 encoded with JSON encoding and newline
-
-	// Check array attribute - should be JSON encoded
-	arrayAttr, ok := event.Attributes["array_attr"].(string)
-	assert.True(t, ok, "array_attr should be a string")
-	assert.Equal(t, "[\"item1\",42,true]\n", arrayAttr)
-
-	// Check kvlist attribute - should be flattened
-	assert.Equal(t, "nested_value", event.Attributes["kvlist_attr.nested_string"])
-	assert.Equal(t, int64(123), event.Attributes["kvlist_attr.nested_int"])
+	attrs := decodeMessagePackAttributes(t, event.Attributes)
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", attrs["trace.trace_id"])
+	assert.Equal(t, "0102030405060708", attrs["trace.span_id"])
+	assert.Equal(t, "test-span", attrs["name"])
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Unpacking large OTLP payloads is hella slow and allocates gobs of memory. We need to avoid handling vast `map[string]any` full of values we probably won't use.

## Short description of the changes
The main thing here is a giant slab of partially machine-generated code which essentially combines the work done by `proto.Unmarshal` and `TranslateTraceRequest` into a single step, while storing the attribute map in serialized messagepack instead of the more traditional `map[string]any`. Why messagepack? Because it's reasonably compact while still very cheap to read (unlike protobuf), and refinery now has a highly optimized path for handling messagepack data through its entire pipeline. Ultimately, so will shepherd.

This also fixes some pretty weird behavior with nested maps where the 6th level deep would not be consistently json-encoded as you'd expect. Porting the existing broken behavior to the new code was more than even my black heart could take.

Lest this seem like a bonkers thing to do, here is the different it makes for refinery's event ingestion when switched to this code:
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkRouterBatch/otlp     187927        26483         -85.91%

benchmark                     old MB/s     new MB/s     speedup
BenchmarkRouterBatch/otlp     73.91        524.44       7.10x

benchmark                     old allocs     new allocs     delta
BenchmarkRouterBatch/otlp     1790           90             -94.97%

benchmark                     old bytes     new bytes     delta
BenchmarkRouterBatch/otlp     254493        21399         -91.59%
```