### PR TITLE
feat: support JSON OTLP in new fast path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.128.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tinylib/msgp v1.3.0
+	github.com/valyala/fastjson v1.6.4
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9
 	google.golang.org/grpc v1.72.2

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tinylib/msgp v1.3.0 h1:ULuf7GPooDaIlbyvgAxBV/FI7ynli6LZ1/nVUNu+0ww=
 github.com/tinylib/msgp v1.3.0/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
+github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
+github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -71,7 +71,11 @@ func TranslateTraceRequestFromReaderSizedWithMsgp(
 		return nil, err
 	}
 
-	if ri.ContentType != "application/protobuf" && ri.ContentType != "application/x-protobuf" {
+	// Check content type
+	switch ri.ContentType {
+	case "application/protobuf", "application/x-protobuf", "application/json":
+		// supported
+	default:
 		return nil, ErrInvalidContentType
 	}
 
@@ -118,7 +122,14 @@ func TranslateTraceRequestFromReaderSizedWithMsgp(
 		return nil, ErrFailedParseBody
 	}
 
-	return unmarshalTraceRequestDirectMsgp(ctx, bodyBuffer.Bytes(), ri)
+	// Unmarshal based on content type
+	switch ri.ContentType {
+	case "application/json":
+		return unmarshalTraceRequestDirectMsgpJSON(ctx, bodyBuffer.Bytes(), ri)
+	default:
+		// protobuf
+		return unmarshalTraceRequestDirectMsgp(ctx, bodyBuffer.Bytes(), ri)
+	}
 }
 
 // TranslateTraceRequest translates an OTLP/gRPC request into Honeycomb-friendly structure

--- a/otlp/traces_direct.go
+++ b/otlp/traces_direct.go
@@ -138,7 +138,6 @@ type msgpAttributes struct {
 	// memoized metadata fields we'll need internally
 	serviceName string
 	sampleRate  int32
-	isError     bool
 }
 
 // Resets state and returns to the pool. Do not re-use after calling this.
@@ -1316,7 +1315,6 @@ func unmarshalSpan(
 					// Error is only set here for the span, then propagated to child events
 					if fields.statusCode == 2 { // STATUS_CODE_ERROR
 						fields.hasError = true
-						eventAttr.isError = true
 					}
 
 				default:

--- a/otlp/traces_direct.go
+++ b/otlp/traces_direct.go
@@ -83,7 +83,6 @@ package otlp
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -291,6 +290,143 @@ func (m *msgpAttributes) addHexID(key []byte, spanID []byte) {
 	m.buf = hex.AppendEncode(m.buf, spanID)
 }
 
+// Holds universal attributes common to all trace event types, or ones which
+// will be output only set when they have a non-default value.
+type commonFields struct {
+	traceID            []byte
+	parentID           []byte
+	parentName         []byte
+	metaAnnotationType string
+	metaSignalType     string
+	hasError           bool
+}
+
+func (s *commonFields) addToMsgpAttributes(attrs *msgpAttributes) {
+	attrs.addTraceID([]byte("trace.trace_id"), s.traceID)
+	if len(s.parentID) > 0 {
+		attrs.addHexID([]byte("trace.parent_id"), s.parentID)
+	}
+
+	// Add parent name if present
+	if len(s.parentName) > 0 {
+		attrs.addString([]byte("parent_name"), s.parentName)
+	}
+
+	// Add metadata - only add annotation type if it's set (not for regular spans)
+	if s.metaAnnotationType != "" {
+		attrs.addString([]byte("meta.annotation_type"), []byte(s.metaAnnotationType))
+	}
+	attrs.addString([]byte("meta.signal_type"), []byte(s.metaSignalType))
+
+	// Add error status if applicable
+	if s.hasError {
+		attrs.addBool([]byte("error"), true)
+	}
+}
+
+// spanFields holds the universal attributes that are set for spans
+type spanFields struct {
+	commonFields
+
+	name               []byte
+	spanID             []byte
+	traceState         []byte
+	statusMessage      []byte
+	spanKind           string
+	statusCode         int64
+	spanNumEvents      int64
+	spanNumLinks       int64
+	durationMs         float64
+	hasInvalidDuration bool
+}
+
+// addToMsgpAttributes adds all the span attributes to the given msgpAttributes
+func (s *spanFields) addToMsgpAttributes(attrs *msgpAttributes) {
+	s.commonFields.addToMsgpAttributes(attrs)
+
+	// Add name (always expected)
+	attrs.addString([]byte("name"), s.name)
+
+	// Add span ID (always expected, even when empty)
+	attrs.addHexID([]byte("trace.span_id"), s.spanID)
+
+	// Add trace state if present
+	if len(s.traceState) > 0 {
+		attrs.addString([]byte("trace.trace_state"), s.traceState)
+	}
+
+	// Add status fields
+	attrs.addInt64([]byte("status_code"), s.statusCode)
+	if len(s.statusMessage) > 0 {
+		attrs.addString([]byte("status_message"), s.statusMessage)
+	}
+
+	// Add span metadata
+	attrs.addInt64([]byte("span.num_events"), s.spanNumEvents)
+	attrs.addInt64([]byte("span.num_links"), s.spanNumLinks)
+	attrs.addString([]byte("span.kind"), []byte(s.spanKind))
+	attrs.addString([]byte("type"), []byte(s.spanKind))
+
+	// Add duration
+	attrs.addFloat64([]byte("duration_ms"), s.durationMs)
+
+	// Set error flag in msgpAttributes for propagation to child events
+	if s.hasError {
+		attrs.isError = true
+	}
+
+	// Add invalid duration flag
+	if s.hasInvalidDuration {
+		attrs.addBool([]byte("meta.invalid_duration"), true)
+	}
+}
+
+// spanEventFields holds the universal attributes that are set for span events
+type spanEventFields struct {
+	commonFields
+
+	name                         []byte
+	timeSinceSpanStartMs         float64
+	hasInvalidTimeSinceSpanStart bool
+}
+
+// addToMsgpAttributes adds all the span event attributes to the given msgpAttributes
+func (s *spanEventFields) addToMsgpAttributes(attrs *msgpAttributes) {
+	s.commonFields.addToMsgpAttributes(attrs)
+
+	// Add name (always expected)
+	attrs.addString([]byte("name"), s.name)
+
+	// Add time since span start
+	attrs.addFloat64([]byte("meta.time_since_span_start_ms"), s.timeSinceSpanStartMs)
+
+	// Add invalid time flag if needed
+	if s.hasInvalidTimeSinceSpanStart {
+		attrs.addBool([]byte("meta.invalid_time_since_span_start"), true)
+	}
+}
+
+// spanLinkFields holds the universal attributes that are set for span links
+type spanLinkFields struct {
+	commonFields
+
+	linkedTraceID []byte
+	linkedSpanID  []byte
+}
+
+// addToMsgpAttributes adds all the span link attributes to the given msgpAttributes
+func (s *spanLinkFields) addToMsgpAttributes(attrs *msgpAttributes) {
+	s.commonFields.addToMsgpAttributes(attrs)
+
+	// Add linked trace and span IDs
+	if len(s.linkedTraceID) > 0 {
+		attrs.addTraceID([]byte("trace.link.trace_id"), s.linkedTraceID)
+	}
+	if len(s.linkedSpanID) > 0 {
+		attrs.addHexID([]byte("trace.link.span_id"), s.linkedSpanID)
+	}
+}
+
 // unmarshalTraceRequestDirectMsgp translates a serialized OTLP trace request directly
 // into a Honeycomb-friendly structure without creating intermediate proto structs,
 // which is EXTREMELY expensive.
@@ -302,7 +438,11 @@ func (m *msgpAttributes) addHexID(key []byte, spanID []byte) {
 // complex than it already is, by adding a new EntityRef field to Resource.
 // https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/resource/v1/resource.proto#L43
 // When this is finalized we'll presumably have to add support here.
-func unmarshalTraceRequestDirectMsgp(ctx context.Context, data []byte, ri RequestInfo) (*TranslateOTLPRequestResultMsgp, error) {
+func unmarshalTraceRequestDirectMsgp(
+	ctx context.Context,
+	data []byte,
+	ri RequestInfo,
+) (*TranslateOTLPRequestResultMsgp, error) {
 	if err := ri.ValidateTracesHeaders(); err != nil {
 		return nil, err
 	}
@@ -520,7 +660,13 @@ func parseKeyValue(data []byte) ([]byte, []byte, error) {
 }
 
 // processValueDirect handles a value recursively, tracking depth for proper flattening
-func processValueDirect(ctx context.Context, key []byte, value any, attrs *msgpAttributes, depth int) error {
+func processValueDirect(
+	ctx context.Context,
+	key []byte,
+	value any,
+	attrs *msgpAttributes,
+	depth int,
+) error {
 	var err error
 
 	// Handle different value types to match legacy behavior
@@ -528,17 +674,11 @@ func processValueDirect(ctx context.Context, key []byte, value any, attrs *msgpA
 	case []byte:
 		// Bytes are JSON encoded - match the legacy behavior
 		husky.AddTelemetryAttribute(ctx, "received_bytes_attr_type", true)
-		err = attrs.addAny(key, addAttributeToMapAsJsonDirect(v))
-		if err != nil {
-			return err
-		}
+		attrs.addString(key, marshalAnyToJSON(v))
 	case []any:
 		// Arrays are JSON encoded
 		husky.AddTelemetryAttribute(ctx, "received_array_attr_type", true)
-		err = attrs.addAny(key, addAttributeToMapAsJsonDirect(v))
-		if err != nil {
-			return err
-		}
+		attrs.addString(key, marshalAnyToJSON(v))
 	case map[string]any:
 		// Kvlists are flattened with dot notation
 		husky.AddTelemetryAttributes(ctx, map[string]any{
@@ -567,10 +707,7 @@ func processValueDirect(ctx context.Context, key []byte, value any, attrs *msgpA
 			}
 		} else {
 			// Max depth exceeded, JSON encode the whole thing
-			err = attrs.addAny(key, addAttributeToMapAsJsonDirect(v))
-			if err != nil {
-				return err
-			}
+			attrs.addString(key, marshalAnyToJSON(v))
 		}
 	default:
 		// Simple types - just encode directly
@@ -1035,11 +1172,16 @@ func unmarshalSpan(
 	defer eventAttr.recycle()
 
 	var eventsData, linksData [][]byte
-	var name, traceID, spanID []byte
-	var statusCode int64
 	var startTimeUnixNano, endTimeUnixNano uint64
-	kindStr := "unspecified"
 	sampleRate := defaultSampleRate
+
+	// Initialize span attributes struct
+	fields := spanFields{
+		commonFields: commonFields{
+			metaSignalType: "trace",
+		},
+		spanKind: "unspecified",
+	}
 
 	l := len(data)
 	iNdEx := 0
@@ -1052,13 +1194,13 @@ func unmarshalSpan(
 
 		switch fieldNum {
 		case 1: // trace_id
-			traceID, err = decodeWireType2(data, &iNdEx, l, wireType)
+			fields.traceID, err = decodeWireType2(data, &iNdEx, l, wireType)
 			if err != nil {
 				return err
 			}
 
 		case 2: // span_id
-			spanID, err = decodeWireType2(data, &iNdEx, l, wireType)
+			fields.spanID, err = decodeWireType2(data, &iNdEx, l, wireType)
 			if err != nil {
 				return err
 			}
@@ -1069,7 +1211,7 @@ func unmarshalSpan(
 				return err
 			}
 			if len(traceState) > 0 {
-				eventAttr.addString([]byte("trace.trace_state"), traceState)
+				fields.traceState = traceState
 
 				rate, ok := getSampleRateFromOTelSamplingThreshold(string(traceState))
 				if ok {
@@ -1083,22 +1225,21 @@ func unmarshalSpan(
 				return err
 			}
 			if len(parentSpanID) > 0 {
-				eventAttr.addHexID([]byte("trace.parent_id"), parentSpanID)
+				fields.parentID = parentSpanID
 			}
 
 		case 5: // name
-			name, err = decodeWireType2(data, &iNdEx, l, wireType)
+			fields.name, err = decodeWireType2(data, &iNdEx, l, wireType)
 			if err != nil {
 				return err
 			}
-			// Will add name below, to make sure it's always added.
 
 		case 6: // kind
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Kind", wireType)
 			}
 			kind := trace.Span_SpanKind(decodeVarint(data, &iNdEx))
-			kindStr = getSpanKind(kind)
+			fields.spanKind = getSpanKind(kind)
 
 		case 7: // start_time_unix_nano
 			v, err := decodeWireType1(data, &iNdEx, l, wireType)
@@ -1163,18 +1304,18 @@ func unmarshalSpan(
 						return err
 					}
 					if len(messageSlice) > 0 {
-						eventAttr.addString([]byte("status_message"), messageSlice)
+						fields.statusMessage = messageSlice
 					}
 
 				case 3: // code
 					if swireType != 0 {
 						return fmt.Errorf("proto: wrong wireType = %d for field Code", swireType)
 					}
-					statusCode = int64(decodeVarint(slice, &siNdEx))
+					fields.statusCode = int64(decodeVarint(slice, &siNdEx))
 					// Check if this is an error status
 					// Error is only set here for the span, then propagated to child events
-					if statusCode == 2 { // STATUS_CODE_ERROR
-						eventAttr.addBool([]byte("error"), true)
+					if fields.statusCode == 2 { // STATUS_CODE_ERROR
+						fields.hasError = true
 						eventAttr.isError = true
 					}
 
@@ -1192,30 +1333,24 @@ func unmarshalSpan(
 		}
 	}
 
-	// Add fields which are always expected, even when they have no encoded value.
-	eventAttr.addTraceID([]byte("trace.trace_id"), traceID)
-	eventAttr.addHexID([]byte("trace.span_id"), spanID)
-	eventAttr.addString([]byte("name"), name)
-	eventAttr.addString([]byte("meta.signal_type"), []byte("trace"))
-	eventAttr.addInt64([]byte("status_code"), statusCode)
-	eventAttr.addInt64([]byte("span.num_events"), int64(len(eventsData)))
-	eventAttr.addInt64([]byte("span.num_links"), int64(len(linksData)))
-	eventAttr.addString([]byte("span.kind"), []byte(kindStr))
-	eventAttr.addString([]byte("type"), []byte(kindStr))
-
-	// Calculate duration
-	duration := float64(0)
+	// Calculate duration directly in spanAttrs
 	if startTimeUnixNano > 0 && endTimeUnixNano > 0 {
 		if endTimeUnixNano >= startTimeUnixNano {
 			durationNs := float64(endTimeUnixNano - startTimeUnixNano)
-			duration = durationNs / float64(time.Millisecond)
+			fields.durationMs = durationNs / float64(time.Millisecond)
 		} else {
 			// Negative duration - endTime is before startTime
-			duration = 0
-			eventAttr.addBool([]byte("meta.invalid_duration"), true)
+			fields.durationMs = 0
+			fields.hasInvalidDuration = true
 		}
 	}
-	eventAttr.addFloat64([]byte("duration_ms"), duration)
+
+	// Populate span attributes struct with remaining fields
+	fields.spanNumEvents = int64(len(eventsData))
+	fields.spanNumLinks = int64(len(linksData))
+
+	// Add all span attributes to eventAttr
+	fields.addToMsgpAttributes(eventAttr)
 
 	timestamp := timestampFromUnixNano(startTimeUnixNano)
 
@@ -1233,9 +1368,9 @@ func unmarshalSpan(
 	for _, eventData := range eventsData {
 		exceptionAttrs, err := unmarshalSpanEvent(ctx,
 			eventData,
-			traceID,
-			spanID,
-			name,
+			fields.traceID,
+			fields.spanID,
+			fields.name,
 			startTimeUnixNano,
 			resourceAttrs,
 			scopeAttrs,
@@ -1262,9 +1397,9 @@ func unmarshalSpan(
 		err := unmarshalSpanLink(
 			ctx,
 			linkData,
-			traceID,
-			spanID,
-			name,
+			fields.traceID,
+			fields.spanID,
+			fields.name,
 			timestamp,
 			resourceAttrs,
 			scopeAttrs,
@@ -1308,25 +1443,19 @@ func unmarshalSpanEvent(
 	eventAttr := msgpAttributesPool.Get().(*msgpAttributes)
 	defer eventAttr.recycle()
 
-	// Set trace info
-	if len(traceID) > 0 {
-		eventAttr.addTraceID([]byte("trace.trace_id"), traceID)
-	}
-	if len(parentSpanID) > 0 {
-		eventAttr.addHexID([]byte("trace.parent_id"), parentSpanID)
-	}
-
-	// Don't generate a span ID for span events - they only have parent_id
-
-	// Mark as span event
-	eventAttr.addString([]byte("meta.annotation_type"), []byte("span_event"))
-	eventAttr.addString([]byte("meta.signal_type"), []byte("trace"))
-	if len(parentName) > 0 {
-		eventAttr.addString([]byte("parent_name"), parentName)
+	// Initialize span event fields struct
+	fields := spanEventFields{
+		commonFields: commonFields{
+			traceID:            traceID,
+			parentID:           parentSpanID,
+			parentName:         parentName,
+			metaAnnotationType: "span_event",
+			metaSignalType:     "trace",
+			hasError:           isError,
+		},
 	}
 
 	// Parse event fields
-	var name []byte
 	var timeUnixNano uint64
 
 	l := len(data)
@@ -1352,7 +1481,7 @@ func unmarshalSpanEvent(
 			if err != nil {
 				return nil, err
 			}
-			name = slice
+			fields.name = slice
 
 		case 3: // attributes
 			slice, err := decodeWireType2(data, &iNdEx, l, wireType)
@@ -1372,25 +1501,19 @@ func unmarshalSpanEvent(
 		}
 	}
 
-	// Set event name
-	eventAttr.addString([]byte("name"), name)
-
 	// Calculate duration relative to span start
 	if timeUnixNano > 0 && spanStartTime > 0 {
 		if timeUnixNano >= spanStartTime {
-			timeSinceSpanStart := float64(timeUnixNano-spanStartTime) / float64(time.Millisecond)
-			eventAttr.addFloat64([]byte("meta.time_since_span_start_ms"), timeSinceSpanStart)
+			fields.timeSinceSpanStartMs = float64(timeUnixNano-spanStartTime) / float64(time.Millisecond)
 		} else {
 			// Event time is before span start time
-			eventAttr.addFloat64([]byte("meta.time_since_span_start_ms"), float64(0))
-			eventAttr.addBool([]byte("meta.invalid_time_since_span_start"), true)
+			fields.timeSinceSpanStartMs = float64(0)
+			fields.hasInvalidTimeSinceSpanStart = true
 		}
 	}
 
-	// Add error status from parent span if applicable
-	if isError {
-		eventAttr.addBool([]byte("error"), true)
-	}
+	// Add all span event fields to eventAttr
+	fields.addToMsgpAttributes(eventAttr)
 
 	eventAttr.addAttributes(scopeAttrs)
 	eventAttr.addAttributes(resourceAttrs)
@@ -1400,7 +1523,7 @@ func unmarshalSpanEvent(
 
 	// Create exception attributes to return if this is an exception event
 	var exceptionAttrs *msgpAttributes
-	if bytes.Equal(name, []byte("exception")) {
+	if bytes.Equal(fields.name, []byte("exception")) {
 		exceptionAttrs = &msgpAttributes{}
 		// We need to parse attributes again to extract exception-specific ones
 		l := len(data)
@@ -1445,8 +1568,13 @@ func unmarshalSpanEvent(
 	return exceptionAttrs, nil
 }
 
-// parseExceptionAttributesForReturn parses KeyValue attributes and adds exception-specific ones to msgpAttributes
-func parseExceptionAttributesForReturn(ctx context.Context, data []byte, exceptionAttrs *msgpAttributes) error {
+// parseExceptionAttributesForReturn parses KeyValue attributes and adds
+// exception-specific ones to msgpAttributes
+func parseExceptionAttributesForReturn(
+	ctx context.Context,
+	data []byte,
+	exceptionAttrs *msgpAttributes,
+) error {
 	key, valueBytes, err := parseKeyValue(data)
 	if err != nil {
 		return err
@@ -1490,25 +1618,19 @@ func unmarshalSpanLink(
 	eventAttr := msgpAttributesPool.Get().(*msgpAttributes)
 	defer eventAttr.recycle()
 
-	// Set trace info
-	if len(traceID) > 0 {
-		eventAttr.addTraceID([]byte("trace.trace_id"), traceID)
-	}
-	if len(parentSpanID) > 0 {
-		eventAttr.addHexID([]byte("trace.parent_id"), parentSpanID)
-	}
-
-	// Don't generate a span ID for span links - they only have parent_id
-
-	// Mark as link
-	eventAttr.addString([]byte("meta.annotation_type"), []byte("link"))
-	eventAttr.addString([]byte("meta.signal_type"), []byte("trace"))
-	if len(parentName) > 0 {
-		eventAttr.addString([]byte("parent_name"), parentName)
+	// Initialize span link fields struct
+	fields := spanLinkFields{
+		commonFields: commonFields{
+			traceID:            traceID,
+			parentID:           parentSpanID,
+			parentName:         parentName,
+			metaAnnotationType: "link",
+			metaSignalType:     "trace",
+			hasError:           isError,
+		},
 	}
 
 	// Parse link fields
-	var linkedTraceID, linkedSpanID []byte
 
 	l := len(data)
 	iNdEx := 0
@@ -1523,14 +1645,14 @@ func unmarshalSpanLink(
 		switch fieldNum {
 		case 1: // trace_id
 			var err error
-			linkedTraceID, err = decodeWireType2(data, &iNdEx, l, wireType)
+			fields.linkedTraceID, err = decodeWireType2(data, &iNdEx, l, wireType)
 			if err != nil {
 				return err
 			}
 
 		case 2: // span_id
 			var err error
-			linkedSpanID, err = decodeWireType2(data, &iNdEx, l, wireType)
+			fields.linkedSpanID, err = decodeWireType2(data, &iNdEx, l, wireType)
 			if err != nil {
 				return err
 			}
@@ -1560,20 +1682,8 @@ func unmarshalSpanLink(
 		}
 	}
 
-	// Set link fields
-	if len(linkedTraceID) > 0 {
-		eventAttr.addTraceID([]byte("trace.link.trace_id"), linkedTraceID)
-	}
-	if len(linkedSpanID) > 0 {
-		eventAttr.addHexID([]byte("trace.link.span_id"), linkedSpanID)
-	}
-	// Note: The original implementation doesn't add trace.link.trace_state
-	// even though it's part of the OTLP spec, so we skip it for compatibility
-
-	// Add error status from parent span if applicable
-	if isError {
-		eventAttr.addBool([]byte("error"), true)
-	}
+	// Add all span link fields to eventAttr
+	fields.addToMsgpAttributes(eventAttr)
 
 	eventAttr.addAttributes(scopeAttrs)
 	eventAttr.addAttributes(resourceAttrs)
@@ -1743,24 +1853,18 @@ func decodeField(data []byte, iNdEx *int) (fieldNum int32, wireType int, err err
 	return
 }
 
-// addAttributeToMapAsJsonDirect converts a value to JSON string, matching the behavior
-// of the legacy addAttributeToMapAsJson function
-func addAttributeToMapAsJsonDirect(val any) string {
-	// Convert bytes to base64 if needed
-	if bytes, ok := val.([]byte); ok {
-		val = base64.StdEncoding.EncodeToString(bytes)
-	}
-
+// marshalAnyToJSON converts a value to JSON string, matching the behavior
+// of the legacy addAttributeToMapAsJson function.
+func marshalAnyToJSON(val any) []byte {
 	// Use json-iterator for consistency with legacy code
-	// fieldSizeMax = math.MaxUint16 from common.go
-	w := newLimitedWriter(math.MaxUint16)
+	w := newLimitedWriter(fieldSizeMax)
 	e := json.NewEncoder(w)
 	e.SetEscapeHTML(false)
 	if err := e.Encode(val); err != nil {
 		// Return empty string on error to match legacy behavior
-		return ""
+		return []byte("")
 	}
-	return w.String()
+	return []byte(w.String())
 }
 
 func getDatasetFromMsgpAttr(ri RequestInfo, attrs *msgpAttributes) string {

--- a/otlp/traces_direct_json.go
+++ b/otlp/traces_direct_json.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"math"
 	"strconv"
 	"time"
 
@@ -218,14 +217,7 @@ func unmarshalAnyValueIntoAttrsJSON(
 			value := v.GetStringBytes()
 
 			// Special handling for sample rate
-			if bytes.Equal(key, []byte("sampleRate")) || bytes.Equal(key, []byte("SampleRate")) {
-				var f float64
-				f, err = strconv.ParseFloat(string(value), 64)
-				if err == nil {
-					if attrs.sampleRate == 0 || bytes.Equal(key, []byte("sampleRate")) {
-						attrs.sampleRate = sampleRateFromFloat(f)
-					}
-				}
+			if isSampleRateKey(key) && trySetSampleRate(key, string(value), attrs) {
 				return
 			}
 
@@ -249,10 +241,7 @@ func unmarshalAnyValueIntoAttrsJSON(
 			}
 
 			// Special handling for sample rate
-			if bytes.Equal(key, []byte("sampleRate")) || bytes.Equal(key, []byte("SampleRate")) {
-				if attrs.sampleRate == 0 || bytes.Equal(key, []byte("sampleRate")) {
-					attrs.sampleRate = int32(max(int64(defaultSampleRate), min(val, math.MaxInt32)))
-				}
+			if isSampleRateKey(key) && trySetSampleRate(key, val, attrs) {
 				return
 			}
 
@@ -262,10 +251,7 @@ func unmarshalAnyValueIntoAttrsJSON(
 			floatVal := v.GetFloat64()
 
 			// Special handling for sample rate
-			if bytes.Equal(key, []byte("sampleRate")) || bytes.Equal(key, []byte("SampleRate")) {
-				if attrs.sampleRate == 0 || bytes.Equal(key, []byte("sampleRate")) {
-					attrs.sampleRate = sampleRateFromFloat(floatVal)
-				}
+			if isSampleRateKey(key) && trySetSampleRate(key, floatVal, attrs) {
 				return
 			}
 

--- a/otlp/traces_direct_json.go
+++ b/otlp/traces_direct_json.go
@@ -1,0 +1,1234 @@
+package otlp
+
+// JSON unmarshaling for OTLP traces, providing direct translation to Honeycomb's
+// event format with serialized messagepack attribute maps, avoiding intermediate
+// allocations.
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/honeycombio/husky"
+
+	jsoniter "github.com/json-iterator/go"
+	trace "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// unmarshalTraceRequestDirectMsgpJSON translates a JSON-encoded OTLP trace request directly
+// into a Honeycomb-friendly structure without creating intermediate proto structs.
+func unmarshalTraceRequestDirectMsgpJSON(
+	ctx context.Context,
+	data []byte,
+	ri RequestInfo,
+) (*TranslateOTLPRequestResultMsgp, error) {
+	if err := ri.ValidateTracesHeaders(); err != nil {
+		return nil, err
+	}
+
+	result := &TranslateOTLPRequestResultMsgp{
+		RequestSize: len(data),
+		Batches:     []BatchMsgp{},
+	}
+
+	// Parse the JSON
+	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, data)
+
+	// Read the root object
+	rootType := iter.WhatIsNext()
+	if rootType != jsoniter.ObjectValue {
+		return nil, fmt.Errorf("expected object at root, got %v", rootType)
+	}
+
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "resourceSpans":
+			if err := unmarshalResourceSpansArrayJSON(ctx, iter, ri, result); err != nil {
+				iter.ReportError("unmarshalResourceSpansArrayJSON", err.Error())
+				return false
+			}
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	if iter.Error != nil {
+		return nil, iter.Error
+	}
+
+	return result, nil
+}
+
+// unmarshalResourceSpansArrayJSON parses an array of ResourceSpans from JSON
+func unmarshalResourceSpansArrayJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	ri RequestInfo,
+	result *TranslateOTLPRequestResultMsgp,
+) error {
+	// Handle null
+	if iter.ReadNil() {
+		return nil
+	}
+
+	// Read array
+	for iter.ReadArray() {
+		if err := unmarshalResourceSpansJSON(ctx, iter, ri, result); err != nil {
+			return err
+		}
+	}
+
+	return iter.Error
+}
+
+// unmarshalResourceSpansJSON parses a ResourceSpans message from JSON
+func unmarshalResourceSpansJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	ri RequestInfo,
+	result *TranslateOTLPRequestResultMsgp,
+) error {
+	var dataset string
+	resourceAttrs := msgpAttributesPool.Get().(*msgpAttributes)
+	defer recycleMsgpAttributes(resourceAttrs)
+
+	// We need to read resource first, then scopeSpans
+	// Store scopeSpans data to process after we have resource
+	var scopeSpansData [][]byte
+
+	// Read the ResourceSpans object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "resource":
+			if err := unmarshalResourceJSON(ctx, iter, resourceAttrs); err != nil {
+				iter.ReportError("unmarshalResourceJSON", err.Error())
+				return false
+			}
+		case "scopeSpans":
+			// Capture the raw JSON for scopeSpans to process later
+			if iter.ReadNil() {
+				return true
+			}
+
+			for iter.ReadArray() {
+				raw := iter.SkipAndReturnBytes()
+				scopeSpansData = append(scopeSpansData, raw)
+			}
+
+			if iter.Error != nil {
+				return false
+			}
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	// Determine dataset from resource attributes
+	dataset = getDatasetFromMsgpAttr(ri, resourceAttrs)
+
+	// Now process scopeSpans with the resource attributes
+	for _, scopeSpansJSON := range scopeSpansData {
+		scopeIter := jsoniter.ParseBytes(jsoniter.ConfigDefault, scopeSpansJSON)
+		if err := unmarshalScopeSpansJSON(ctx, scopeIter, resourceAttrs, dataset, result); err != nil {
+			return err
+		}
+		if scopeIter.Error != nil {
+			return scopeIter.Error
+		}
+	}
+
+	return nil
+}
+
+// unmarshalResourceJSON parses a Resource message from JSON
+func unmarshalResourceJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	attrs *msgpAttributes,
+) error {
+	if iter.ReadNil() {
+		return nil
+	}
+
+	// Read the Resource object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "attributes":
+			if err := unmarshalKeyValueArrayJSON(ctx, iter, attrs, 0); err != nil {
+				iter.ReportError("unmarshalKeyValueArrayJSON", err.Error())
+				return false
+			}
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	return iter.Error
+}
+
+// unmarshalKeyValueArrayJSON parses an array of KeyValue from JSON
+func unmarshalKeyValueArrayJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	attrs *msgpAttributes, depth int,
+) error {
+	if iter.ReadNil() {
+		return nil
+	}
+
+	// Read array
+	for iter.ReadArray() {
+		if err := unmarshalKeyValueJSON(ctx, iter, attrs, depth); err != nil {
+			return err
+		}
+	}
+
+	return iter.Error
+}
+
+// unmarshalKeyValueJSON parses a KeyValue message from JSON and adds it to msgpAttributes
+func unmarshalKeyValueJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	attrs *msgpAttributes, depth int,
+) error {
+	var key string
+	var valueProcessed bool
+
+	// Read the KeyValue object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "key":
+			key = iter.ReadString()
+		case "value":
+			if key != "" && !valueProcessed {
+				if err := unmarshalAnyValueIntoAttrsJSON(ctx, iter, []byte(key), attrs, depth); err != nil {
+					iter.ReportError("unmarshalAnyValueIntoAttrsJSON", err.Error())
+					return false
+				}
+				valueProcessed = true
+			} else {
+				iter.Skip()
+			}
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	return iter.Error
+}
+
+// unmarshalAnyValueIntoAttrsJSON parses an AnyValue from JSON and adds it directly to msgpAttributes
+func unmarshalAnyValueIntoAttrsJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	key []byte,
+	attrs *msgpAttributes,
+	depth int,
+) error {
+	if iter.ReadNil() {
+		return nil
+	}
+
+	// Read the AnyValue object to determine its type
+	// JSON encoding uses field names like "stringValue", "intValue", etc.
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "stringValue":
+			value := iter.ReadString()
+
+			// Special handling for sample rate
+			if bytes.Equal(key, []byte("sampleRate")) || bytes.Equal(key, []byte("SampleRate")) {
+				if f, err := strconv.ParseFloat(value, 64); err == nil {
+					if attrs.sampleRate == 0 || bytes.Equal(key, []byte("sampleRate")) {
+						attrs.sampleRate = sampleRateFromFloat(f)
+					}
+				}
+				return true // Continue processing other fields even though we've handled sampleRate
+			}
+
+			// Check for service name
+			if bytes.Equal(key, []byte("service.name")) {
+				attrs.serviceName = value
+			}
+
+			attrs.addString(key, []byte(value))
+
+		case "boolValue":
+			attrs.addBool(key, iter.ReadBool())
+
+		case "intValue":
+			// JSON encodes int64 as string
+			strVal := iter.ReadString()
+			v, err := strconv.ParseInt(strVal, 10, 64)
+			if err != nil {
+				iter.ReportError("ParseInt", fmt.Sprintf("failed to parse intValue: %v", err))
+				return false
+			}
+
+			// Special handling for sample rate
+			if bytes.Equal(key, []byte("sampleRate")) || bytes.Equal(key, []byte("SampleRate")) {
+				v = min(v, math.MaxInt32)
+				if attrs.sampleRate == 0 || bytes.Equal(key, []byte("sampleRate")) {
+					attrs.sampleRate = max(defaultSampleRate, int32(v))
+				}
+				return true // Continue processing other fields
+			}
+
+			attrs.addInt64(key, v)
+
+		case "doubleValue":
+			floatVal := iter.ReadFloat64()
+
+			// Special handling for sample rate
+			if bytes.Equal(key, []byte("sampleRate")) || bytes.Equal(key, []byte("SampleRate")) {
+				if attrs.sampleRate == 0 || bytes.Equal(key, []byte("sampleRate")) {
+					attrs.sampleRate = sampleRateFromFloat(floatVal)
+				}
+				return true // Continue processing other fields
+			}
+
+			attrs.addFloat64(key, floatVal)
+
+		case "bytesValue":
+			// Bytes are base64 encoded in JSON
+			strVal := iter.ReadString()
+			b, err := base64.StdEncoding.DecodeString(strVal)
+			if err != nil {
+				iter.ReportError("DecodeString", fmt.Sprintf("failed to decode bytesValue: %v", err))
+				return false
+			}
+
+			husky.AddTelemetryAttribute(ctx, "received_bytes_attr_type", true)
+			err = attrs.addAny(key, addAttributeToMapAsJsonDirect(b))
+			if err != nil {
+				iter.ReportError("addAny", err.Error())
+				return false
+			}
+
+		case "arrayValue":
+			// For arrays, we need to parse and JSON encode
+			// We can't skip unmarshal/marshal because we need to transform from OTLP format
+			// (with AnyValue wrappers) to simplified JSON format
+			husky.AddTelemetryAttribute(ctx, "received_array_attr_type", true)
+			arr, err := unmarshalArrayValueJSON(ctx, iter)
+			if err != nil {
+				iter.ReportError("unmarshalArrayValueJSON", err.Error())
+				return false
+			}
+			err = attrs.addAny(key, addAttributeToMapAsJsonDirect(arr))
+			if err != nil {
+				iter.ReportError("addAny", err.Error())
+				return false
+			}
+
+		case "kvlistValue":
+			// For kvlists, handle flattening
+			husky.AddTelemetryAttributes(ctx, map[string]any{
+				"received_kvlist_attr_type": true,
+				"kvlist_max_depth":          depth,
+			})
+
+			if depth < maxDepth {
+				// Flatten the kvlist
+				if err := unmarshalKvlistValueFlattenJSON(ctx, iter, key, attrs, depth+1); err != nil {
+					iter.ReportError("unmarshalKvlistValueFlattenJSON", err.Error())
+					return false
+				}
+			} else {
+				// Max depth exceeded, JSON encode the whole thing
+				m, err := unmarshalKvlistValueJSON(ctx, iter)
+				if err != nil {
+					iter.ReportError("unmarshalKvlistValueJSON", err.Error())
+					return false
+				}
+				err = attrs.addAny(key, addAttributeToMapAsJsonDirect(m))
+				if err != nil {
+					iter.ReportError("addAny", err.Error())
+					return false
+				}
+			}
+
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	return iter.Error
+}
+
+// unmarshalArrayValueJSON parses an ArrayValue from JSON and returns []any
+func unmarshalArrayValueJSON(ctx context.Context, iter *jsoniter.Iterator) ([]any, error) {
+	var values []any
+
+	// Read the ArrayValue object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "values":
+			if !iter.ReadNil() {
+				for iter.ReadArray() {
+					val, err := unmarshalAnyValueJSON(ctx, iter)
+					if err != nil {
+						iter.ReportError("unmarshalAnyValueJSON", err.Error())
+						return false
+					}
+					if val != nil {
+						values = append(values, val)
+					}
+				}
+			}
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	return values, iter.Error
+}
+
+// unmarshalAnyValueJSON parses an AnyValue from JSON and returns the value
+func unmarshalAnyValueJSON(ctx context.Context, iter *jsoniter.Iterator) (any, error) {
+	if iter.ReadNil() {
+		return nil, nil
+	}
+
+	var result any
+
+	// Read the AnyValue object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "stringValue":
+			result = iter.ReadString()
+
+		case "boolValue":
+			result = iter.ReadBool()
+
+		case "intValue":
+			// JSON encodes int64 as string
+			strVal := iter.ReadString()
+			v, err := strconv.ParseInt(strVal, 10, 64)
+			if err != nil {
+				iter.ReportError("ParseInt", fmt.Sprintf("failed to parse intValue: %v", err))
+				return false
+			}
+			result = v
+
+		case "doubleValue":
+			result = iter.ReadFloat64()
+
+		case "bytesValue":
+			// Bytes are base64 encoded in JSON
+			strVal := iter.ReadString()
+			b, err := base64.StdEncoding.DecodeString(strVal)
+			if err != nil {
+				iter.ReportError("DecodeString", fmt.Sprintf("failed to decode bytesValue: %v", err))
+				return false
+			}
+			result = b
+
+		case "arrayValue":
+			arr, err := unmarshalArrayValueJSON(ctx, iter)
+			if err != nil {
+				iter.ReportError("unmarshalArrayValueJSON", err.Error())
+				return false
+			}
+			result = arr
+
+		case "kvlistValue":
+			m, err := unmarshalKvlistValueJSON(ctx, iter)
+			if err != nil {
+				iter.ReportError("unmarshalKvlistValueJSON", err.Error())
+				return false
+			}
+			result = m
+
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	return result, iter.Error
+}
+
+// unmarshalKvlistValueFlattenJSON parses a KeyValueList from JSON and flattens it into msgpAttributes
+func unmarshalKvlistValueFlattenJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	keyPrefix []byte,
+	attrs *msgpAttributes,
+	depth int,
+) error {
+	// Read the KeyValueList object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "values":
+			if !iter.ReadNil() {
+				for iter.ReadArray() {
+					// Parse each KeyValue in the list
+					var key string
+					var valueProcessed bool
+
+					iter.ReadObjectCB(func(iter *jsoniter.Iterator, kvField string) bool {
+						switch kvField {
+						case "key":
+							key = iter.ReadString()
+						case "value":
+							if key != "" && !valueProcessed {
+								// Create flattened key
+								flatKey := append(keyPrefix, '.')
+								flatKey = append(flatKey, key...)
+
+								// Process the value with AnyValue unmarshaling
+								if err := unmarshalAnyValueIntoAttrsJSON(ctx, iter, flatKey, attrs, depth); err != nil {
+									iter.ReportError("unmarshalAnyValueIntoAttrsJSON", err.Error())
+									return false
+								}
+								valueProcessed = true
+							} else {
+								iter.Skip()
+							}
+						default:
+							iter.Skip()
+						}
+						return true
+					})
+
+					if iter.Error != nil {
+						return false
+					}
+				}
+			}
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	return iter.Error
+}
+
+// unmarshalKvlistValueJSON parses a KeyValueList from JSON and returns map[string]any
+func unmarshalKvlistValueJSON(ctx context.Context, iter *jsoniter.Iterator) (map[string]any, error) {
+	result := make(map[string]any)
+
+	// Read the KeyValueList object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "values":
+			if !iter.ReadNil() {
+				for iter.ReadArray() {
+					// Parse each KeyValue in the list
+					var key string
+					var val any
+
+					iter.ReadObjectCB(func(iter *jsoniter.Iterator, kvField string) bool {
+						switch kvField {
+						case "key":
+							key = iter.ReadString()
+						case "value":
+							v, err := unmarshalAnyValueJSON(ctx, iter)
+							if err != nil {
+								iter.ReportError("unmarshalAnyValueJSON", err.Error())
+								return false
+							}
+							val = v
+						default:
+							iter.Skip()
+						}
+						return true
+					})
+
+					if iter.Error != nil {
+						return false
+					}
+
+					if key != "" && val != nil {
+						result[key] = val
+					}
+				}
+			}
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	return result, iter.Error
+}
+
+// unmarshalScopeSpansJSON parses a ScopeSpans message from JSON
+func unmarshalScopeSpansJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	resourceAttrs *msgpAttributes,
+	dataset string,
+	result *TranslateOTLPRequestResultMsgp,
+) error {
+	scopeAttrs := msgpAttributesPool.Get().(*msgpAttributes)
+	defer recycleMsgpAttributes(scopeAttrs)
+
+	// Store spans data to process after we have scope
+	var spansData [][]byte
+
+	// Read the ScopeSpans object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "scope":
+			if err := unmarshalInstrumentationScopeJSON(ctx, iter, scopeAttrs); err != nil {
+				iter.ReportError("unmarshalInstrumentationScopeJSON", err.Error())
+				return false
+			}
+		case "spans":
+			// Capture the raw JSON for spans to process later
+			if !iter.ReadNil() {
+				for iter.ReadArray() {
+					raw := iter.SkipAndReturnBytes()
+					spansData = append(spansData, raw)
+				}
+			}
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	if iter.Error != nil {
+		return iter.Error
+	}
+
+	// Now process spans with both resource and scope attributes
+	for _, spanJSON := range spansData {
+		spanIter := jsoniter.ParseBytes(jsoniter.ConfigDefault, spanJSON)
+		if err := unmarshalSpanJSON(ctx, spanIter, resourceAttrs, scopeAttrs, dataset, result); err != nil {
+			return err
+		}
+		if spanIter.Error != nil {
+			return spanIter.Error
+		}
+	}
+
+	return nil
+}
+
+// unmarshalInstrumentationScopeJSON parses an InstrumentationScope message from JSON
+func unmarshalInstrumentationScopeJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	attrs *msgpAttributes,
+) error {
+	if iter.ReadNil() {
+		return nil
+	}
+
+	// Read the InstrumentationScope object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "name":
+			name := iter.ReadString()
+			if name != "" {
+				attrs.addString([]byte("library.name"), []byte(name))
+				if isInstrumentationLibrary(name) {
+					attrs.addBool([]byte("telemetry.instrumentation_library"), true)
+				}
+			}
+		case "version":
+			version := iter.ReadString()
+			if version != "" {
+				attrs.addString([]byte("library.version"), []byte(version))
+			}
+		case "attributes":
+			if err := unmarshalKeyValueArrayJSON(ctx, iter, attrs, 0); err != nil {
+				iter.ReportError("unmarshalKeyValueArrayJSON", err.Error())
+				return false
+			}
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	return iter.Error
+}
+
+// unmarshalSpanJSON parses a Span message from JSON and creates an event
+func unmarshalSpanJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	resourceAttrs,
+	scopeAttrs *msgpAttributes,
+	dataset string,
+	result *TranslateOTLPRequestResultMsgp,
+) error {
+	// Find or create the batch for this dataset
+	var batch *BatchMsgp
+	for i := range result.Batches {
+		if result.Batches[i].Dataset == dataset {
+			batch = &result.Batches[i]
+			break
+		}
+	}
+	if batch == nil {
+		result.Batches = append(result.Batches, BatchMsgp{
+			Dataset: dataset,
+			Events:  []EventMsgp{},
+		})
+		batch = &result.Batches[len(result.Batches)-1]
+	}
+
+	eventAttr := newMsgpMap()
+	defer recycleMsgpAttributes(eventAttr.msgpAttributes)
+
+	var eventsData, linksData [][]byte
+	var name, traceID, spanID []byte
+	var traceState string
+	var statusCode int64
+	var startTimeUnixNano, endTimeUnixNano uint64
+	sampleRate := defaultSampleRate
+
+	// Read the Span object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "traceId":
+			// Trace ID is base64 encoded in JSON
+			strVal := iter.ReadString()
+			b, err := base64.StdEncoding.DecodeString(strVal)
+			if err != nil {
+				iter.ReportError("DecodeString", fmt.Sprintf("failed to decode traceId: %v", err))
+				return false
+			}
+			traceID = b
+			if len(traceID) > 0 {
+				eventAttr.addTraceID([]byte("trace.trace_id"), traceID)
+			}
+
+		case "spanId":
+			// Span ID is base64 encoded in JSON
+			strVal := iter.ReadString()
+			b, err := base64.StdEncoding.DecodeString(strVal)
+			if err != nil {
+				iter.ReportError("DecodeString", fmt.Sprintf("failed to decode spanId: %v", err))
+				return false
+			}
+			spanID = b
+			if len(spanID) > 0 {
+				eventAttr.addHexID([]byte("trace.span_id"), spanID)
+			}
+
+		case "traceState":
+			traceState = iter.ReadString()
+			if traceState != "" {
+				eventAttr.addString([]byte("trace.trace_state"), []byte(traceState))
+
+				rate, ok := getSampleRateFromOTelSamplingThreshold(traceState)
+				if ok {
+					sampleRate = rate
+				}
+			}
+
+		case "parentSpanId":
+			// Parent span ID is base64 encoded in JSON
+			strVal := iter.ReadString()
+			b, err := base64.StdEncoding.DecodeString(strVal)
+			if err != nil {
+				iter.ReportError("DecodeString", fmt.Sprintf("failed to decode parentSpanId: %v", err))
+				return false
+			}
+			if len(b) > 0 {
+				eventAttr.addHexID([]byte("trace.parent_id"), b)
+			}
+
+		case "name":
+			nameStr := iter.ReadString()
+			name = []byte(nameStr)
+
+		case "kind":
+			// In JSON, kind can be either string enum name or integer
+			if iter.WhatIsNext() == jsoniter.StringValue {
+				// String enum like "SPAN_KIND_SERVER"
+				kindStr := iter.ReadString()
+				// Map from protobuf enum string to our string representation
+				var kind string
+				switch kindStr {
+				case "SPAN_KIND_UNSPECIFIED":
+					kind = "unspecified"
+				case "SPAN_KIND_INTERNAL":
+					kind = "internal"
+				case "SPAN_KIND_SERVER":
+					kind = "server"
+				case "SPAN_KIND_CLIENT":
+					kind = "client"
+				case "SPAN_KIND_PRODUCER":
+					kind = "producer"
+				case "SPAN_KIND_CONSUMER":
+					kind = "consumer"
+				default:
+					kind = "unspecified"
+				}
+				eventAttr.addString([]byte("span.kind"), []byte(kind))
+				eventAttr.addString([]byte("type"), []byte(kind))
+			} else {
+				// Integer value
+				kind := trace.Span_SpanKind(iter.ReadInt())
+				kindStr := getSpanKind(kind)
+				eventAttr.addString([]byte("span.kind"), []byte(kindStr))
+				eventAttr.addString([]byte("type"), []byte(kindStr))
+			}
+
+		case "startTimeUnixNano":
+			// Time is encoded as string in JSON
+			strVal := iter.ReadString()
+			v, err := strconv.ParseUint(strVal, 10, 64)
+			if err != nil {
+				iter.ReportError("ParseUint", fmt.Sprintf("failed to parse startTimeUnixNano: %v", err))
+				return false
+			}
+			startTimeUnixNano = v
+
+		case "endTimeUnixNano":
+			// Time is encoded as string in JSON
+			strVal := iter.ReadString()
+			v, err := strconv.ParseUint(strVal, 10, 64)
+			if err != nil {
+				iter.ReportError("ParseUint", fmt.Sprintf("failed to parse endTimeUnixNano: %v", err))
+				return false
+			}
+			endTimeUnixNano = v
+
+		case "attributes":
+			if err := unmarshalKeyValueArrayJSON(ctx, iter, eventAttr.msgpAttributes, 0); err != nil {
+				iter.ReportError("unmarshalKeyValueArrayJSON", err.Error())
+				return false
+			}
+
+		case "events":
+			// Capture the raw JSON for events to process later
+			if !iter.ReadNil() {
+				for iter.ReadArray() {
+					raw := iter.SkipAndReturnBytes()
+					eventsData = append(eventsData, raw)
+				}
+			}
+
+		case "links":
+			// Capture the raw JSON for links to process later
+			if !iter.ReadNil() {
+				for iter.ReadArray() {
+					raw := iter.SkipAndReturnBytes()
+					linksData = append(linksData, raw)
+				}
+			}
+
+		case "status":
+			if !iter.ReadNil() {
+				// Parse status object
+				iter.ReadObjectCB(func(iter *jsoniter.Iterator, statusField string) bool {
+					switch statusField {
+					case "message":
+						message := iter.ReadString()
+						if message != "" {
+							eventAttr.addString([]byte("status_message"), []byte(message))
+						}
+					case "code":
+						// In JSON, code can be either string enum or integer
+						if iter.WhatIsNext() == jsoniter.StringValue {
+							// String enum like "STATUS_CODE_OK"
+							codeStr := iter.ReadString()
+							switch codeStr {
+							case "STATUS_CODE_UNSET":
+								statusCode = 0
+							case "STATUS_CODE_OK":
+								statusCode = 1
+							case "STATUS_CODE_ERROR":
+								statusCode = 2
+								eventAttr.addBool([]byte("error"), true)
+								eventAttr.isError = true
+							default:
+								statusCode = 0
+							}
+						} else {
+							// Integer value
+							statusCode = int64(iter.ReadInt())
+							// Check if this is an error status
+							if statusCode == 2 { // STATUS_CODE_ERROR
+								eventAttr.addBool([]byte("error"), true)
+								eventAttr.isError = true
+							}
+						}
+					default:
+						iter.Skip()
+					}
+					return true
+				})
+			}
+
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	if iter.Error != nil {
+		return iter.Error
+	}
+
+	// Add fields which are always expected
+	eventAttr.addString([]byte("name"), name)
+	eventAttr.addString([]byte("meta.signal_type"), []byte("trace"))
+	eventAttr.addInt64([]byte("status_code"), statusCode)
+	eventAttr.addInt64([]byte("span.num_events"), int64(len(eventsData)))
+	eventAttr.addInt64([]byte("span.num_links"), int64(len(linksData)))
+
+	eventAttr.addAttributes(resourceAttrs)
+	eventAttr.addAttributes(scopeAttrs)
+
+	// Calculate duration
+	duration := float64(0)
+	if startTimeUnixNano > 0 && endTimeUnixNano > 0 {
+		if endTimeUnixNano >= startTimeUnixNano {
+			durationNs := float64(endTimeUnixNano - startTimeUnixNano)
+			duration = durationNs / float64(time.Millisecond)
+		} else {
+			// Negative duration
+			duration = 0
+			eventAttr.addBool([]byte("meta.invalid_duration"), true)
+		}
+	}
+	eventAttr.addFloat64([]byte("duration_ms"), duration)
+
+	timestamp := timestampFromUnixNano(startTimeUnixNano)
+
+	// Get the final sample rate
+	if eventAttr.sampleRate != 0 {
+		sampleRate = eventAttr.sampleRate
+	}
+
+	// Process span events first
+	var firstExceptionAttrs *msgpAttributes
+	for _, eventJSON := range eventsData {
+		eventIter := jsoniter.ParseBytes(jsoniter.ConfigDefault, eventJSON)
+		exceptionAttrs, err := unmarshalSpanEventJSON(ctx, eventIter, traceID, spanID, name, startTimeUnixNano, resourceAttrs, scopeAttrs, sampleRate, eventAttr.isError, batch)
+		if err != nil {
+			return err
+		}
+		if eventIter.Error != nil {
+			return eventIter.Error
+		}
+		// Only keep the first exception's attributes
+		if exceptionAttrs != nil && firstExceptionAttrs == nil {
+			firstExceptionAttrs = exceptionAttrs
+		}
+	}
+
+	// Add exception attributes from the first exception event to the parent span
+	if firstExceptionAttrs != nil {
+		eventAttr.addAttributes(firstExceptionAttrs)
+		recycleMsgpAttributes(firstExceptionAttrs)
+	}
+
+	// Process span links next
+	for _, linkJSON := range linksData {
+		linkIter := jsoniter.ParseBytes(jsoniter.ConfigDefault, linkJSON)
+		err := unmarshalSpanLinkJSON(ctx, linkIter, traceID, spanID, name, timestamp, resourceAttrs, scopeAttrs, sampleRate, eventAttr.isError, batch)
+		if err != nil {
+			return err
+		}
+		if linkIter.Error != nil {
+			return linkIter.Error
+		}
+	}
+
+	// Add the span event last
+	attrBuf, err := eventAttr.finalize()
+	if err != nil {
+		return err
+	}
+	event := EventMsgp{
+		Attributes: attrBuf,
+		SampleRate: sampleRate,
+		Timestamp:  timestamp,
+	}
+	batch.Events = append(batch.Events, event)
+
+	return iter.Error
+}
+
+// unmarshalSpanEventJSON parses a Span.Event message from JSON and creates an event
+// Returns exception attributes if this is an exception event, nil otherwise
+func unmarshalSpanEventJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	traceID,
+	parentSpanID,
+	parentName []byte,
+	spanStartTime uint64,
+	resourceAttrs,
+	scopeAttrs *msgpAttributes,
+	sampleRate int32,
+	isError bool,
+	batch *BatchMsgp,
+) (*msgpAttributes, error) {
+	eventAttr := newMsgpMap()
+
+	// Set trace info
+	if len(traceID) > 0 {
+		eventAttr.addTraceID([]byte("trace.trace_id"), traceID)
+	}
+	if len(parentSpanID) > 0 {
+		eventAttr.addHexID([]byte("trace.parent_id"), parentSpanID)
+	}
+
+	// Mark as span event
+	eventAttr.addString([]byte("meta.annotation_type"), []byte("span_event"))
+	eventAttr.addString([]byte("meta.signal_type"), []byte("trace"))
+	if len(parentName) > 0 {
+		eventAttr.addString([]byte("parent_name"), parentName)
+	}
+
+	// Parse event fields
+	var name []byte
+	var timeUnixNano uint64
+	var exceptionAttrs *msgpAttributes
+	var attrData []byte
+
+	// Read the Event object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "timeUnixNano":
+			// Time is encoded as string in JSON
+			strVal := iter.ReadString()
+			v, err := strconv.ParseUint(strVal, 10, 64)
+			if err != nil {
+				iter.ReportError("ParseUint", fmt.Sprintf("failed to parse timeUnixNano: %v", err))
+				return false
+			}
+			timeUnixNano = v
+
+		case "name":
+			nameStr := iter.ReadString()
+			name = []byte(nameStr)
+
+		case "attributes":
+			// Store raw attributes data to process after we know the event name
+			attrData = iter.SkipAndReturnBytes()
+
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	if iter.Error != nil {
+		return nil, iter.Error
+	}
+
+	// Now process attributes if we have them
+	if len(attrData) > 0 {
+		// Parse attributes into event
+		attrIter := jsoniter.ParseBytes(jsoniter.ConfigDefault, attrData)
+		if err := unmarshalKeyValueArrayJSON(ctx, attrIter, eventAttr.msgpAttributes, 0); err != nil {
+			return nil, err
+		}
+
+		// If this is an exception event, also collect exception-specific attributes
+		if bytes.Equal(name, []byte("exception")) {
+			exceptionAttrs = msgpAttributesPool.Get().(*msgpAttributes)
+
+			// Re-parse to extract exception attributes
+			attrIter2 := jsoniter.ParseBytes(jsoniter.ConfigDefault, attrData)
+			for attrIter2.ReadArray() {
+				var key string
+				attrIter2.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+					switch field {
+					case "key":
+						key = iter.ReadString()
+					case "value":
+						// Only process if it's an exception attribute
+						switch key {
+						case "exception.message", "exception.type", "exception.stacktrace":
+							iter.ReadObjectCB(func(iter *jsoniter.Iterator, valueField string) bool {
+								if valueField == "stringValue" {
+									val := iter.ReadString()
+									exceptionAttrs.addString([]byte(key), []byte(val))
+								} else {
+									iter.Skip()
+								}
+								return true
+							})
+						case "exception.escaped":
+							iter.ReadObjectCB(func(iter *jsoniter.Iterator, valueField string) bool {
+								if valueField == "boolValue" {
+									val := iter.ReadBool()
+									exceptionAttrs.addBool([]byte(key), val)
+								} else {
+									iter.Skip()
+								}
+								return true
+							})
+						default:
+							iter.Skip()
+						}
+					default:
+						iter.Skip()
+					}
+					return true
+				})
+			}
+		}
+	}
+
+	// Set event name
+	eventAttr.addString([]byte("name"), name)
+
+	// Calculate duration relative to span start
+	if timeUnixNano > 0 && spanStartTime > 0 {
+		if timeUnixNano >= spanStartTime {
+			timeSinceSpanStart := float64(timeUnixNano-spanStartTime) / float64(time.Millisecond)
+			eventAttr.addFloat64([]byte("meta.time_since_span_start_ms"), timeSinceSpanStart)
+		} else {
+			// Event time is before span start time
+			eventAttr.addFloat64([]byte("meta.time_since_span_start_ms"), float64(0))
+			eventAttr.addBool([]byte("meta.invalid_time_since_span_start"), true)
+		}
+	}
+
+	// Add error status from parent span if applicable
+	if isError {
+		eventAttr.addBool([]byte("error"), true)
+	}
+
+	// Add resource and scope attributes
+	eventAttr.addAttributes(resourceAttrs)
+	eventAttr.addAttributes(scopeAttrs)
+
+	// Set timestamp
+	timestamp := timestampFromUnixNano(timeUnixNano)
+
+	attrBuf, err := eventAttr.finalize()
+	if err != nil {
+		return nil, err
+	}
+	event := EventMsgp{
+		Attributes: attrBuf,
+		SampleRate: sampleRate,
+		Timestamp:  timestamp,
+	}
+	batch.Events = append(batch.Events, event)
+	return exceptionAttrs, nil
+}
+
+// unmarshalSpanLinkJSON parses a Span.Link message from JSON and creates an event
+func unmarshalSpanLinkJSON(
+	ctx context.Context,
+	iter *jsoniter.Iterator,
+	traceID,
+	parentSpanID,
+	parentName []byte,
+	parentTimestamp time.Time,
+	resourceAttrs,
+	scopeAttrs *msgpAttributes,
+	sampleRate int32,
+	isError bool,
+	batch *BatchMsgp,
+) error {
+	eventAttr := newMsgpMap()
+
+	// Set trace info
+	if len(traceID) > 0 {
+		eventAttr.addTraceID([]byte("trace.trace_id"), traceID)
+	}
+	if len(parentSpanID) > 0 {
+		eventAttr.addHexID([]byte("trace.parent_id"), parentSpanID)
+	}
+
+	// Mark as link
+	eventAttr.addString([]byte("meta.annotation_type"), []byte("link"))
+	eventAttr.addString([]byte("meta.signal_type"), []byte("trace"))
+	if len(parentName) > 0 {
+		eventAttr.addString([]byte("parent_name"), parentName)
+	}
+
+	// Parse link fields
+	var linkedTraceID, linkedSpanID []byte
+
+	// Read the Link object
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
+		switch field {
+		case "traceId":
+			// Trace ID is base64 encoded in JSON
+			strVal := iter.ReadString()
+			b, err := base64.StdEncoding.DecodeString(strVal)
+			if err != nil {
+				iter.ReportError("DecodeString", fmt.Sprintf("failed to decode link traceId: %v", err))
+				return false
+			}
+			linkedTraceID = b
+
+		case "spanId":
+			// Span ID is base64 encoded in JSON
+			strVal := iter.ReadString()
+			b, err := base64.StdEncoding.DecodeString(strVal)
+			if err != nil {
+				iter.ReportError("DecodeString", fmt.Sprintf("failed to decode link spanId: %v", err))
+				return false
+			}
+			linkedSpanID = b
+
+		case "traceState":
+			// Skip trace_state - original implementation doesn't add it
+			iter.Skip()
+
+		case "attributes":
+			if err := unmarshalKeyValueArrayJSON(ctx, iter, eventAttr.msgpAttributes, 0); err != nil {
+				iter.ReportError("unmarshalKeyValueArrayJSON", err.Error())
+				return false
+			}
+
+		default:
+			iter.Skip()
+		}
+		return true
+	})
+
+	if iter.Error != nil {
+		return iter.Error
+	}
+
+	// Set link fields
+	if len(linkedTraceID) > 0 {
+		eventAttr.addTraceID([]byte("trace.link.trace_id"), linkedTraceID)
+	}
+	if len(linkedSpanID) > 0 {
+		eventAttr.addHexID([]byte("trace.link.span_id"), linkedSpanID)
+	}
+
+	// Add error status from parent span if applicable
+	if isError {
+		eventAttr.addBool([]byte("error"), true)
+	}
+
+	// Add resource and scope attributes
+	eventAttr.addAttributes(resourceAttrs)
+	eventAttr.addAttributes(scopeAttrs)
+
+	attrBuf, err := eventAttr.finalize()
+	if err != nil {
+		return err
+	}
+	event := EventMsgp{
+		Attributes: attrBuf,
+		SampleRate: sampleRate,
+		Timestamp:  parentTimestamp,
+	}
+	batch.Events = append(batch.Events, event)
+	return nil
+}

--- a/otlp/traces_direct_json.go
+++ b/otlp/traces_direct_json.go
@@ -250,9 +250,8 @@ func unmarshalAnyValueIntoAttrsJSON(
 
 			// Special handling for sample rate
 			if bytes.Equal(key, []byte("sampleRate")) || bytes.Equal(key, []byte("SampleRate")) {
-				val = min(val, math.MaxInt32)
 				if attrs.sampleRate == 0 || bytes.Equal(key, []byte("sampleRate")) {
-					attrs.sampleRate = max(defaultSampleRate, int32(val))
+					attrs.sampleRate = int32(max(int64(defaultSampleRate), min(val, math.MaxInt32)))
 				}
 				return
 			}

--- a/otlp/traces_direct_json.go
+++ b/otlp/traces_direct_json.go
@@ -586,7 +586,7 @@ func unmarshalInstrumentationScopeJSON(
 func unmarshalSpanJSON(
 	ctx context.Context,
 	v *fastjson.Value,
-	resourceAttrs,
+	resourceAttrs *msgpAttributes,
 	scopeAttrs *msgpAttributes,
 	batch *BatchMsgp,
 ) error {
@@ -741,7 +741,6 @@ func unmarshalSpanJSON(
 						case "STATUS_CODE_ERROR":
 							fields.statusCode = 2
 							fields.hasError = true
-							eventAttr.isError = true
 						default:
 							fields.statusCode = 0
 						}
@@ -751,7 +750,6 @@ func unmarshalSpanJSON(
 						// Check if this is an error status
 						if fields.statusCode == 2 { // STATUS_CODE_ERROR
 							fields.hasError = true
-							eventAttr.isError = true
 						}
 					}
 				}
@@ -804,7 +802,7 @@ func unmarshalSpanJSON(
 			resourceAttrs,
 			scopeAttrs,
 			sampleRate,
-			eventAttr.isError,
+			fields.hasError,
 			batch,
 		)
 		if err != nil {
@@ -834,7 +832,7 @@ func unmarshalSpanJSON(
 			resourceAttrs,
 			scopeAttrs,
 			sampleRate,
-			eventAttr.isError,
+			fields.hasError,
 			batch,
 		)
 		if err != nil {
@@ -862,11 +860,11 @@ func unmarshalSpanJSON(
 func unmarshalSpanEventJSON(
 	ctx context.Context,
 	v *fastjson.Value,
-	traceID,
-	parentSpanID,
+	traceID []byte,
+	parentSpanID []byte,
 	parentName []byte,
 	spanStartTime uint64,
-	resourceAttrs,
+	resourceAttrs *msgpAttributes,
 	scopeAttrs *msgpAttributes,
 	sampleRate int32,
 	isError bool,
@@ -1013,11 +1011,11 @@ func unmarshalSpanEventJSON(
 func unmarshalSpanLinkJSON(
 	ctx context.Context,
 	v *fastjson.Value,
-	traceID,
-	parentSpanID,
+	traceID []byte,
+	parentSpanID []byte,
 	parentName []byte,
 	parentTimestamp time.Time,
-	resourceAttrs,
+	resourceAttrs *msgpAttributes,
 	scopeAttrs *msgpAttributes,
 	sampleRate int32,
 	isError bool,

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -1253,32 +1253,64 @@ func BenchmarkUnmarshalTraceRequestDirectMsgp(b *testing.B) {
 		},
 	}
 
-	ri := RequestInfo{
-		ApiKey:      "abc123DEF456ghi789jklm",
-		Dataset:     "benchmark-dataset",
-		ContentType: "application/protobuf",
-	}
+	// Run sub-benchmarks for protobuf and JSON
+	b.Run("Protobuf", func(b *testing.B) {
+		ri := RequestInfo{
+			ApiKey:      "abc123DEF456ghi789jklm",
+			Dataset:     "benchmark-dataset",
+			ContentType: "application/protobuf",
+		}
 
-	// Serialize the request once before benchmarking
-	data, err := proto.Marshal(req)
-	if err != nil {
-		b.Fatal("Failed to serialize trace request:", err)
-	}
-	ctx := context.Background()
-
-	// Reset timer to exclude setup time
-	b.ResetTimer()
-
-	// Run the benchmark
-	for i := 0; i < b.N; i++ {
-		result, err := unmarshalTraceRequestDirectMsgp(ctx, data, ri)
+		// Serialize the request once before benchmarking
+		data, err := proto.Marshal(req)
 		if err != nil {
-			b.Fatal(err)
+			b.Fatal("Failed to serialize trace request:", err)
 		}
-		if len(result.Batches) != 1 || len(result.Batches[0].Events) != 1 {
-			b.Fatal("unexpected result structure")
+		ctx := context.Background()
+
+		// Reset timer to exclude setup time
+		b.ResetTimer()
+
+		// Run the benchmark
+		for i := 0; i < b.N; i++ {
+			result, err := unmarshalTraceRequestDirectMsgp(ctx, data, ri)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(result.Batches) != 1 || len(result.Batches[0].Events) != 1 {
+				b.Fatal("unexpected result structure")
+			}
 		}
-	}
+	})
+
+	b.Run("JSON", func(b *testing.B) {
+		ri := RequestInfo{
+			ApiKey:      "abc123DEF456ghi789jklm",
+			Dataset:     "benchmark-dataset",
+			ContentType: "application/json",
+		}
+
+		// Serialize the request to JSON once before benchmarking
+		jsonData, err := protojson.Marshal(req)
+		if err != nil {
+			b.Fatal("Failed to serialize trace request to JSON:", err)
+		}
+		ctx := context.Background()
+
+		// Reset timer to exclude setup time
+		b.ResetTimer()
+
+		// Run the benchmark
+		for i := 0; i < b.N; i++ {
+			result, err := unmarshalTraceRequestDirectMsgpJSON(ctx, jsonData, ri)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(result.Batches) != 1 || len(result.Batches[0].Events) != 1 {
+				b.Fatal("unexpected result structure")
+			}
+		}
+	})
 }
 
 func TestSampleRateFromFloat(t *testing.T) {

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -237,6 +237,12 @@ func TestUnmarshalTraceRequestDirect_Complete(t *testing.T) {
 											Value: &common.AnyValue_IntValue{IntValue: 10},
 										},
 									},
+									{
+										Key: `unfriendly\to "json"`,
+										Value: &common.AnyValue{
+											Value: &common.AnyValue_StringValue{StringValue: `I need\ to "escape"`},
+										},
+									},
 									// Empty and nil values are dropped from the output.
 									{
 										Key: "empty.attr",
@@ -589,6 +595,7 @@ func TestUnmarshalTraceRequestDirect_Complete(t *testing.T) {
 				"http.url":             "https://example.com/api/users",
 				"response.size":        float64(1234.56),
 				"success":              true,
+				`unfriendly\to "json"`: `I need\ to "escape"`,
 				"status_code":          int64(1),
 				"status_message":       "Request completed successfully",
 				"duration_ms":          float64(864.197532),


### PR DESCRIPTION
## Which problem is this PR solving?
JSON is still a thing even in 2025 - some SDKs ONLY support sending the JSON flavor of OTLP. We'll need to handle this efficiently.

## Short description of the changes
This extends the work in #307 with a JSON version mirroring the proto version. It's not great to have, in effect, two copies of the same business logic, but I think the language gymnastics we'd have to do to consolidate it between both implementations in an efficient way would make the code truly impenetrable. We'll have to have a lot of faith in our testing - `TestUnmarshalTraceRequestDirect_Complete` now includes JSON.

I'm using fastjson because jsoniter doesn't actually support zero-allocation object iteration. Unfortunately both libraries appear to be abandonware, with no modern alternative on the horizon.

This is much slower than protobuf, but that's to be expected, and at least it's in the same ballpark.
```
BenchmarkUnmarshalTraceRequestDirectMsgp/Protobuf-12         	  156210	      6451 ns/op	    3377 B/op	       5 allocs/op
BenchmarkUnmarshalTraceRequestDirectMsgp/JSON-12             	   71346	     16525 ns/op	    3430 B/op	       7 allocs/op
```