### PR TITLE
feat: export UnmarshalTraceRequestDirectMsgp

### DIFF
--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -128,7 +128,7 @@ func TranslateTraceRequestFromReaderSizedWithMsgp(
 		return unmarshalTraceRequestDirectMsgpJSON(ctx, bodyBuffer.Bytes(), ri)
 	default:
 		// protobuf
-		return unmarshalTraceRequestDirectMsgp(ctx, bodyBuffer.Bytes(), ri)
+		return UnmarshalTraceRequestDirectMsgp(ctx, bodyBuffer.Bytes(), ri)
 	}
 }
 

--- a/otlp/traces_direct.go
+++ b/otlp/traces_direct.go
@@ -439,7 +439,7 @@ func trySetSampleRate(key []byte, value any, attrs *msgpAttributes) bool {
 	return false
 }
 
-// unmarshalTraceRequestDirectMsgp translates a serialized OTLP trace request directly
+// UnmarshalTraceRequestDirectMsgp translates a serialized OTLP trace request directly
 // into a Honeycomb-friendly structure without creating intermediate proto structs,
 // which is EXTREMELY expensive.
 // Why does the code look like this? Because it's derived from gogo's generated
@@ -450,7 +450,7 @@ func trySetSampleRate(key []byte, value any, attrs *msgpAttributes) bool {
 // complex than it already is, by adding a new EntityRef field to Resource.
 // https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/resource/v1/resource.proto#L43
 // When this is finalized we'll presumably have to add support here.
-func unmarshalTraceRequestDirectMsgp(
+func UnmarshalTraceRequestDirectMsgp(
 	ctx context.Context,
 	data []byte,
 	ri RequestInfo,

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -530,7 +530,7 @@ func TestUnmarshalTraceRequestDirect_Complete(t *testing.T) {
 			serialize: func(req *collectortrace.ExportTraceServiceRequest) ([]byte, error) {
 				return proto.Marshal(req)
 			},
-			unmarshal: unmarshalTraceRequestDirectMsgp,
+			unmarshal: UnmarshalTraceRequestDirectMsgp,
 		},
 		{
 			name:        "json",
@@ -1020,7 +1020,7 @@ func TestUnmarshalTraceRequestDirect_WithUnknownFields(t *testing.T) {
 	}
 
 	// The direct unmarshaling should skip unknown fields gracefully
-	result, err := unmarshalTraceRequestDirectMsgp(context.Background(), data, ri)
+	result, err := UnmarshalTraceRequestDirectMsgp(context.Background(), data, ri)
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.Batches, 1)
@@ -1301,7 +1301,7 @@ func TestUnmarshalTraceRequestDirect_NestedMapAttributes(t *testing.T) {
 			serialize: func(req *collectortrace.ExportTraceServiceRequest) ([]byte, error) {
 				return proto.Marshal(req)
 			},
-			unmarshal: unmarshalTraceRequestDirectMsgp,
+			unmarshal: UnmarshalTraceRequestDirectMsgp,
 		},
 		{
 			name:        "json",
@@ -1503,7 +1503,7 @@ func BenchmarkUnmarshalTraceRequestDirectMsgp(b *testing.B) {
 
 		// Run the benchmark
 		for i := 0; i < b.N; i++ {
-			result, err := unmarshalTraceRequestDirectMsgp(ctx, data, ri)
+			result, err := UnmarshalTraceRequestDirectMsgp(ctx, data, ri)
 			if err != nil {
 				b.Fatal(err)
 			}


### PR DESCRIPTION
## Which problem is this PR solving?
TranslateTraceRequestFromReaderSizedWithMsgp is designed for HTTP endpoints, where you have a reader and a content type. In GRPC-land, you're handed an already-read []byte which is assumed to be protobuf, so we can skip a level of indirection and buffering if we go directly to the unmarshal function for GRPC requests.

## Short description of the changes
Just renames the function.
