### PR TITLE
maint: prepare for release v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Husky Changelog
 
+## 0.38.0 2025-08-08
+
+- feat: export UnmarshalTraceRequestDirectMsgp (#309) | [ianwilkes](https://github.com/ianwilkes)
+- feat: support JSON OTLP in new fast path (#308) | [ianwilkes](https://github.com/ianwilkes)
+- feat: alternative optimized proto -> messagepack path for traces (#307) | [ianwilkes](https://github.com/ianwilkes)
+- perf: optimize API key variant check (#310) | [Robb Kidd](https://github.com/RobbKidd)
+- maint(deps): bump the minor-patch group with 3 updates (#311) | [dependabot[bot]](https://github.com/dependabot[bot])
+- maint(deps): bump the minor-patch group with 2 updates (#306) | [dependabot[bot]](https://github.com/dependabot[bot])
+
 ## 0.37.0 2025-06-24
 
 - feat: Add the JS honeycomb prefix (#304) | @martin308

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package husky
 
 var (
-	Version string = "0.37.0"
+	Version string = "0.38.0"
 )


### PR DESCRIPTION
## Which problem is this PR solving?

Prepare for v0.38.0 release that contains features that enables direct translation between OTLP and messagepack

## Short description of the changes

- update version.go
- update changelog

