### PR TITLE
fix: parse intValue from json as either a number or a string

### DIFF
--- a/otlp/traces_direct_json.go
+++ b/otlp/traces_direct_json.go
@@ -55,6 +55,11 @@ func unmarshalTraceRequestDirectMsgpJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "resourceSpans":
 			resourceSpansArray := v.GetArray()
@@ -87,6 +92,8 @@ func unmarshalResourceSpansJSON(
 
 	var scopeSpansArray []*fastjson.Value
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -134,6 +141,8 @@ func unmarshalResourceJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -182,6 +191,8 @@ func unmarshalKeyValueJSON(
 	var keyBytes []byte
 	var valueObj *fastjson.Value
 	obj.Visit(func(k []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -222,6 +233,8 @@ func unmarshalAnyValueIntoAttrsJSON(
 
 	// Visit the object once to find the value type
 	obj.Visit(func(k []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -246,7 +259,7 @@ func unmarshalAnyValueIntoAttrsJSON(
 			attrs.addBool(key, v.GetBool())
 
 		case "intValue":
-			// In JSON, code can be either string enum or integer
+			// In JSON, code can be either string or integer
 			var val int64
 			switch v.Type() {
 			case fastjson.TypeNumber:
@@ -336,6 +349,8 @@ func unmarshalArrayValueJSON(ctx context.Context, v *fastjson.Value) ([]any, err
 	var values []any
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -371,6 +386,8 @@ func unmarshalAnyValueJSON(ctx context.Context, v *fastjson.Value) (any, error) 
 
 	var result any
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -431,6 +448,8 @@ func unmarshalKvlistValueJSON(ctx context.Context, v *fastjson.Value) (map[strin
 
 	result := make(map[string]any)
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -488,6 +507,8 @@ func unmarshalKvlistValueFlattenJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -555,6 +576,8 @@ func unmarshalScopeSpansJSON(
 
 	var spansArray []*fastjson.Value
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -593,6 +616,11 @@ func unmarshalInstrumentationScopeJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "name":
 			nameBytes := v.GetStringBytes()
@@ -652,6 +680,8 @@ func unmarshalSpanJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -765,6 +795,8 @@ func unmarshalSpanJSON(
 				return
 			}
 			statusObj.Visit(func(k []byte, v *fastjson.Value) {
+				// Closure-based error handling
+				// if err is set, all subsequent visits are no-ops
 				if err != nil {
 					return
 				}
@@ -944,6 +976,8 @@ func unmarshalSpanEventJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}
@@ -1095,6 +1129,8 @@ func unmarshalSpanLinkJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		// Closure-based error handling
+		// if err is set, all subsequent visits are no-ops
 		if err != nil {
 			return
 		}

--- a/otlp/traces_direct_json.go
+++ b/otlp/traces_direct_json.go
@@ -87,6 +87,9 @@ func unmarshalResourceSpansJSON(
 
 	var scopeSpansArray []*fastjson.Value
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "resource":
 			err = unmarshalResourceJSON(ctx, v, resourceAttrs)
@@ -131,6 +134,9 @@ func unmarshalResourceJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "attributes":
 			attributes := v.GetArray()
@@ -176,6 +182,9 @@ func unmarshalKeyValueJSON(
 	var keyBytes []byte
 	var valueObj *fastjson.Value
 	obj.Visit(func(k []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
 		switch string(k) {
 		case "key":
 			// CAUTION: GetStringBytes() returns references to the input buffer.
@@ -213,6 +222,10 @@ func unmarshalAnyValueIntoAttrsJSON(
 
 	// Visit the object once to find the value type
 	obj.Visit(func(k []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
+
 		switch string(k) {
 		case "stringValue":
 			value := v.GetStringBytes()
@@ -323,6 +336,9 @@ func unmarshalArrayValueJSON(ctx context.Context, v *fastjson.Value) ([]any, err
 	var values []any
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "values":
 			valuesArray := v.GetArray()
@@ -355,6 +371,9 @@ func unmarshalAnyValueJSON(ctx context.Context, v *fastjson.Value) (any, error) 
 
 	var result any
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "stringValue":
 			result = string(v.GetStringBytes())
@@ -412,6 +431,9 @@ func unmarshalKvlistValueJSON(ctx context.Context, v *fastjson.Value) (map[strin
 
 	result := make(map[string]any)
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "values":
 			valuesArray := v.GetArray()
@@ -466,6 +488,9 @@ func unmarshalKvlistValueFlattenJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "values":
 			valuesArray := v.GetArray()
@@ -480,6 +505,9 @@ func unmarshalKvlistValueFlattenJSON(
 				var valueObj *fastjson.Value
 
 				valueObject.Visit(func(k []byte, v *fastjson.Value) {
+					if err != nil {
+						return
+					}
 					switch string(k) {
 					case "key":
 						keyBytes = v.GetStringBytes()
@@ -527,6 +555,9 @@ func unmarshalScopeSpansJSON(
 
 	var spansArray []*fastjson.Value
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "scope":
 			if err = unmarshalInstrumentationScopeJSON(ctx, v, scopeAttrs); err != nil {
@@ -621,6 +652,10 @@ func unmarshalSpanJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
+
 		switch string(key) {
 		case "traceId":
 			// Trace ID is base64 encoded in JSON
@@ -730,6 +765,9 @@ func unmarshalSpanJSON(
 				return
 			}
 			statusObj.Visit(func(k []byte, v *fastjson.Value) {
+				if err != nil {
+					return
+				}
 				switch string(k) {
 				case "message":
 					messageBytes := v.GetStringBytes()
@@ -906,6 +944,9 @@ func unmarshalSpanEventJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
 		switch string(key) {
 		case "timeUnixNano":
 			// Time is encoded as string in JSON
@@ -1054,6 +1095,10 @@ func unmarshalSpanLinkJSON(
 	}
 
 	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
+
 		switch string(key) {
 		case "traceId":
 			// Trace ID is base64 encoded in JSON

--- a/otlp/traces_direct_json.go
+++ b/otlp/traces_direct_json.go
@@ -812,22 +812,23 @@ func unmarshalSpanJSON(
 					case fastjson.TypeNumber:
 						fields.statusCode = int64(v.GetInt())
 						// Check if this is an error status
-						if fields.statusCode == 2 { // STATUS_CODE_ERROR
+						if fields.statusCode == int64(trace.Status_STATUS_CODE_ERROR) {
 							fields.hasError = true
 						}
 					case fastjson.TypeString:
-						// String enum like "STATUS_CODE_OK"
 						codeBytes := v.GetStringBytes()
+						// cases based on trace.Status_StatusCode enum
 						switch string(codeBytes) {
 						case "STATUS_CODE_UNSET":
-							fields.statusCode = 0
+							fields.statusCode = int64(trace.Status_STATUS_CODE_UNSET)
 						case "STATUS_CODE_OK":
-							fields.statusCode = 1
+							fields.statusCode = int64(trace.Status_STATUS_CODE_OK)
 						case "STATUS_CODE_ERROR":
-							fields.statusCode = 2
+							fields.statusCode = int64(trace.Status_STATUS_CODE_ERROR)
 							fields.hasError = true
 						default:
-							fields.statusCode = 0
+							// if the status string is unrecognizable, we assume UNSET
+							fields.statusCode = int64(trace.Status_STATUS_CODE_UNSET)
 						}
 					default:
 						err = errors.New("parse error: expected value as a string or a number.")

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -1786,67 +1786,31 @@ func TestUnmarshalTraceRequestDirectJSON_ErrorHandling(t *testing.T) {
 			}`,
 			errorMsg: "", // fastjson will return a parse error
 		},
-	}
-
-	// Add comprehensive test cases using the helper function - organized by level with one test per data type
-	comprehensiveTestCases := []struct {
-		name          string
-		errorLocation string
-		invalidValue  string
-		expectedError string
-	}{
-		//		// Resource level - one test per data type
-		//		{"resource_int_error", "resource.process.pid", "not-a-number", "invalid syntax"},
-		//		{"resource_bool_error", "resource.bool.attr", "not-a-bool", "invalid syntax"},
-		//		{"resource_double_error", "resource.double.attr", "not-a-double", "invalid syntax"},
-		//		{"resource_bytes_error", "resource.bytes.attr", "invalid-base64!", "invalid syntax"},
-		//
-		//		// Scope level - one test per data type
-		//		{"scope_int_error", "scope.attribute.int", "invalid-int", "invalid syntax"},
-		//		{"scope_bool_error", "scope.attribute.bool", "invalid-bool", "invalid syntax"},
-		//		{"scope_double_error", "scope.attribute.double", "invalid-double", "invalid syntax"},
-		//
-		//		// Span core fields - one test per field type
-		//		{"span_traceId_error", "span.traceId", "invalid-trace-id", "invalid syntax"},
-		//		{"span_spanId_error", "span.spanId", "invalid-span-id", "invalid syntax"},
-		//		{"span_parentSpanId_error", "span.parentSpanId", "invalid-parent-id", "invalid syntax"},
-		//		{"span_kind_error", "span.kind", "invalid-kind", "invalid syntax"},
-		//		{"span_startTime_error", "span.startTime", "invalid-timestamp", "invalid syntax"},
-		//		{"span_endTime_error", "span.endTime", "invalid-timestamp", "invalid syntax"},
-
-		// Span attributes - one test per data type
-		{"span_attribute_int_error", "span.http.status_code", "not-a-number", "invalid syntax"},
-		//		{"span_attribute_bool_error", "span.custom.bool", "not-a-bool", "invalid syntax"},
-		//		{"span_attribute_double_error", "span.custom.double", "not-a-double", "invalid syntax"},
-		//
-		//		// Event - one test per data type
-		//		{"event_timestamp_error", "event1.time", "invalid-timestamp", "invalid syntax"},
-		//		{"event_int_error", "event1.cache.ttl", "invalid-int", "invalid syntax"},
-		//		{"event_double_error", "event1.cache.hit_ratio", "invalid-double", "invalid syntax"},
-		//		{"event_bool_error", "event1.cache.enabled", "invalid-bool", "invalid syntax"},
-		//
-		//		// Link - one test per data type
-		//		{"link_traceId_error", "link1.traceId", "invalid-trace-id", "invalid syntax"},
-		//		{"link_spanId_error", "link1.spanId", "invalid-span-id", "invalid syntax"},
-		//		{"link_int_error", "link1.priority", "invalid-int", "invalid syntax"},
-		//		{"link_double_error", "link1.weight", "invalid-double", "invalid syntax"},
-		//		{"link_bool_error", "link1.active", "invalid-bool", "invalid syntax"},
-		//
-		//		// Status - one test per field type
-		//		{"status_code_error", "status.code", "invalid-status", "invalid syntax"},
-	}
-
-	// Add comprehensive test cases to the main test cases slice
-	for _, ctc := range comprehensiveTestCases {
-		testCases = append(testCases, struct {
-			name     string
-			jsonData string
-			errorMsg string
-		}{
-			name:     ctc.name,
-			jsonData: generateComprehensiveOTLPTraceJSON(ctc.errorLocation, ctc.invalidValue),
-			errorMsg: ctc.expectedError,
-		})
+		{
+			name:     "resource_int_error",
+			jsonData: generateComprehensiveOTLPTraceJSON("resource.process.pid", "not-a-number"),
+			errorMsg: "invalid syntax",
+		},
+		{
+			name:     "scope_int_error",
+			jsonData: generateComprehensiveOTLPTraceJSON("scope.attribute.int", "invalid-int"),
+			errorMsg: "invalid syntax",
+		},
+		{
+			name:     "span_attribute_int_error",
+			jsonData: generateComprehensiveOTLPTraceJSON("span.http.status_code", "not-a-number"),
+			errorMsg: "invalid syntax",
+		},
+		{
+			name:     "event_int_error",
+			jsonData: generateComprehensiveOTLPTraceJSON("event1.cache.ttl", "invalid-int"),
+			errorMsg: "invalid syntax",
+		},
+		{
+			name:     "link_int_error",
+			jsonData: generateComprehensiveOTLPTraceJSON("link1.priority", "invalid-int"),
+			errorMsg: "invalid syntax",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -1543,6 +1543,181 @@ func BenchmarkUnmarshalTraceRequestDirectMsgp(b *testing.B) {
 	})
 }
 
+// generateComprehensiveOTLPTraceJSON generates a comprehensive OTLP trace request JSON
+// with all possible fields populated. The errorLocation parameter specifies where
+// to inject an invalid field that should cause parsing to fail.
+func generateComprehensiveOTLPTraceJSON(errorLocation string, invalidValue string) string {
+	// Helper functions to inject errors based on location and data type
+	getIntValue := func(location string, validValue int) interface{} {
+		if errorLocation == location {
+			return invalidValue
+		}
+		return validValue
+	}
+
+	getBoolValue := func(location string, validValue bool) interface{} {
+		if errorLocation == location {
+			return invalidValue
+		}
+		return validValue
+	}
+
+	getDoubleValue := func(location string, validValue float64) interface{} {
+		if errorLocation == location {
+			return invalidValue
+		}
+		return validValue
+	}
+
+	getStringValue := func(location, validValue string) string {
+		if errorLocation == location {
+			return invalidValue
+		}
+		return validValue
+	}
+
+	getTraceId := func(location, validValue string) string {
+		if errorLocation == location {
+			return invalidValue
+		}
+		return validValue
+	}
+
+	getSpanId := func(location, validValue string) string {
+		if errorLocation == location {
+			return invalidValue
+		}
+		return validValue
+	}
+
+	getTimestamp := func(location, validValue string) string {
+		if errorLocation == location {
+			return invalidValue
+		}
+		return validValue
+	}
+
+	// Build the JSON structure programmatically to handle different data types correctly
+	data := map[string]interface{}{
+		"resourceSpans": []map[string]interface{}{
+			{
+				"resource": map[string]interface{}{
+					"attributes": []map[string]interface{}{
+						{
+							"key":   "process.pid",
+							"value": map[string]interface{}{"intValue": getIntValue("resource.process.pid", 12345)},
+						},
+						{
+							"key":   "bool.attr",
+							"value": map[string]interface{}{"boolValue": getBoolValue("resource.bool.attr", true)},
+						},
+						{
+							"key":   "double.attr",
+							"value": map[string]interface{}{"doubleValue": getDoubleValue("resource.double.attr", 123.456)},
+						},
+						{
+							"key":   "bytes.attr",
+							"value": map[string]interface{}{"bytesValue": getStringValue("resource.bytes.attr", "aGVsbG8gd29ybGQ=")},
+						},
+					},
+				},
+				"scopeSpans": []map[string]interface{}{
+					{
+						"scope": map[string]interface{}{
+							"name":    "test-scope",
+							"version": "1.2.3",
+							"attributes": []map[string]interface{}{
+								{
+									"key":   "attribute.int",
+									"value": map[string]interface{}{"intValue": getIntValue("scope.attribute.int", 456)},
+								},
+								{
+									"key":   "attribute.bool",
+									"value": map[string]interface{}{"boolValue": getBoolValue("scope.attribute.bool", false)},
+								},
+								{
+									"key":   "attribute.double",
+									"value": map[string]interface{}{"doubleValue": getDoubleValue("scope.attribute.double", 789.123)},
+								},
+							},
+						},
+						"spans": []map[string]interface{}{
+							{
+								"traceId":           getTraceId("span.traceId", "AQIDBAUGAAAAAAAAAAAAAAAAAA=="),
+								"spanId":            getSpanId("span.spanId", "AQIDBAUGAA=="),
+								"parentSpanId":      getSpanId("span.parentSpanId", "ERERFREUAAAAAA=="),
+								"name":              "test-span",
+								"kind":              getIntValue("span.kind", 2),
+								"startTimeUnixNano": getTimestamp("span.startTime", "1234567890123456789"),
+								"endTimeUnixNano":   getTimestamp("span.endTime", "1234567890987654321"),
+								"attributes": []map[string]interface{}{
+									{
+										"key":   "http.status_code",
+										"value": map[string]interface{}{"intValue": getIntValue("span.http.status_code", 200)},
+									},
+									{
+										"key":   "custom.bool",
+										"value": map[string]interface{}{"boolValue": getBoolValue("span.custom.bool", true)},
+									},
+									{
+										"key":   "custom.double",
+										"value": map[string]interface{}{"doubleValue": getDoubleValue("span.custom.double", 12.34)},
+									},
+								},
+								"events": []map[string]interface{}{
+									{
+										"timeUnixNano": getTimestamp("event1.time", "1234567890223456789"),
+										"name":         "cache.hit",
+										"attributes": []map[string]interface{}{
+											{
+												"key":   "cache.ttl",
+												"value": map[string]interface{}{"intValue": getIntValue("event1.cache.ttl", 3600)},
+											},
+											{
+												"key":   "cache.hit_ratio",
+												"value": map[string]interface{}{"doubleValue": getDoubleValue("event1.cache.hit_ratio", 0.85)},
+											},
+											{
+												"key":   "cache.enabled",
+												"value": map[string]interface{}{"boolValue": getBoolValue("event1.cache.enabled", true)},
+											},
+										},
+									},
+								},
+								"links": []map[string]interface{}{
+									{
+										"traceId": getTraceId("link1.traceId", "MTIzNDU2Nzg5OnV7PD0+P0E="),
+										"spanId":  getSpanId("link1.spanId", "QUJDREVGRkg="),
+										"attributes": []map[string]interface{}{
+											{
+												"key":   "priority",
+												"value": map[string]interface{}{"intValue": getIntValue("link1.priority", 5)},
+											},
+											{
+												"key":   "weight",
+												"value": map[string]interface{}{"doubleValue": getDoubleValue("link1.weight", 0.75)},
+											},
+											{
+												"key":   "active",
+												"value": map[string]interface{}{"boolValue": getBoolValue("link1.active", true)},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"code": getIntValue("status.code", 1),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonBytes, _ := json.Marshal(data)
+	return string(jsonBytes)
+}
 func TestUnmarshalTraceRequestDirectJSON_ErrorHandling(t *testing.T) {
 	ctx := context.Background()
 	ri := RequestInfo{
@@ -1613,10 +1788,71 @@ func TestUnmarshalTraceRequestDirectJSON_ErrorHandling(t *testing.T) {
 		},
 	}
 
+	// Add comprehensive test cases using the helper function - organized by level with one test per data type
+	comprehensiveTestCases := []struct {
+		name          string
+		errorLocation string
+		invalidValue  string
+		expectedError string
+	}{
+		//		// Resource level - one test per data type
+		//		{"resource_int_error", "resource.process.pid", "not-a-number", "invalid syntax"},
+		//		{"resource_bool_error", "resource.bool.attr", "not-a-bool", "invalid syntax"},
+		//		{"resource_double_error", "resource.double.attr", "not-a-double", "invalid syntax"},
+		//		{"resource_bytes_error", "resource.bytes.attr", "invalid-base64!", "invalid syntax"},
+		//
+		//		// Scope level - one test per data type
+		//		{"scope_int_error", "scope.attribute.int", "invalid-int", "invalid syntax"},
+		//		{"scope_bool_error", "scope.attribute.bool", "invalid-bool", "invalid syntax"},
+		//		{"scope_double_error", "scope.attribute.double", "invalid-double", "invalid syntax"},
+		//
+		//		// Span core fields - one test per field type
+		//		{"span_traceId_error", "span.traceId", "invalid-trace-id", "invalid syntax"},
+		//		{"span_spanId_error", "span.spanId", "invalid-span-id", "invalid syntax"},
+		//		{"span_parentSpanId_error", "span.parentSpanId", "invalid-parent-id", "invalid syntax"},
+		//		{"span_kind_error", "span.kind", "invalid-kind", "invalid syntax"},
+		//		{"span_startTime_error", "span.startTime", "invalid-timestamp", "invalid syntax"},
+		//		{"span_endTime_error", "span.endTime", "invalid-timestamp", "invalid syntax"},
+
+		// Span attributes - one test per data type
+		{"span_attribute_int_error", "span.http.status_code", "not-a-number", "invalid syntax"},
+		//		{"span_attribute_bool_error", "span.custom.bool", "not-a-bool", "invalid syntax"},
+		//		{"span_attribute_double_error", "span.custom.double", "not-a-double", "invalid syntax"},
+		//
+		//		// Event - one test per data type
+		//		{"event_timestamp_error", "event1.time", "invalid-timestamp", "invalid syntax"},
+		//		{"event_int_error", "event1.cache.ttl", "invalid-int", "invalid syntax"},
+		//		{"event_double_error", "event1.cache.hit_ratio", "invalid-double", "invalid syntax"},
+		//		{"event_bool_error", "event1.cache.enabled", "invalid-bool", "invalid syntax"},
+		//
+		//		// Link - one test per data type
+		//		{"link_traceId_error", "link1.traceId", "invalid-trace-id", "invalid syntax"},
+		//		{"link_spanId_error", "link1.spanId", "invalid-span-id", "invalid syntax"},
+		//		{"link_int_error", "link1.priority", "invalid-int", "invalid syntax"},
+		//		{"link_double_error", "link1.weight", "invalid-double", "invalid syntax"},
+		//		{"link_bool_error", "link1.active", "invalid-bool", "invalid syntax"},
+		//
+		//		// Status - one test per field type
+		//		{"status_code_error", "status.code", "invalid-status", "invalid syntax"},
+	}
+
+	// Add comprehensive test cases to the main test cases slice
+	for _, ctc := range comprehensiveTestCases {
+		testCases = append(testCases, struct {
+			name     string
+			jsonData string
+			errorMsg string
+		}{
+			name:     ctc.name,
+			jsonData: generateComprehensiveOTLPTraceJSON(ctc.errorLocation, ctc.invalidValue),
+			errorMsg: ctc.expectedError,
+		})
+	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := unmarshalTraceRequestDirectMsgpJSON(ctx, []byte(tc.jsonData), ri)
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errorMsg)
 		})
 	}

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -1555,48 +1555,6 @@ func generateComprehensiveOTLPTraceJSON(errorLocation string, invalidValue strin
 		return validValue
 	}
 
-	getBoolValue := func(location string, validValue bool) interface{} {
-		if errorLocation == location {
-			return invalidValue
-		}
-		return validValue
-	}
-
-	getDoubleValue := func(location string, validValue float64) interface{} {
-		if errorLocation == location {
-			return invalidValue
-		}
-		return validValue
-	}
-
-	getStringValue := func(location, validValue string) string {
-		if errorLocation == location {
-			return invalidValue
-		}
-		return validValue
-	}
-
-	getTraceId := func(location, validValue string) string {
-		if errorLocation == location {
-			return invalidValue
-		}
-		return validValue
-	}
-
-	getSpanId := func(location, validValue string) string {
-		if errorLocation == location {
-			return invalidValue
-		}
-		return validValue
-	}
-
-	getTimestamp := func(location, validValue string) string {
-		if errorLocation == location {
-			return invalidValue
-		}
-		return validValue
-	}
-
 	// Build the JSON structure programmatically to handle different data types correctly
 	data := map[string]interface{}{
 		"resourceSpans": []map[string]interface{}{
@@ -1604,20 +1562,20 @@ func generateComprehensiveOTLPTraceJSON(errorLocation string, invalidValue strin
 				"resource": map[string]interface{}{
 					"attributes": []map[string]interface{}{
 						{
-							"key":   "process.pid",
-							"value": map[string]interface{}{"intValue": getIntValue("resource.process.pid", 12345)},
+							"key":   "int.attr",
+							"value": map[string]interface{}{"intValue": getIntValue("resource.int.attr", 12345)},
 						},
 						{
 							"key":   "bool.attr",
-							"value": map[string]interface{}{"boolValue": getBoolValue("resource.bool.attr", true)},
+							"value": true,
 						},
 						{
 							"key":   "double.attr",
-							"value": map[string]interface{}{"doubleValue": getDoubleValue("resource.double.attr", 123.456)},
+							"value": 123.456,
 						},
 						{
 							"key":   "bytes.attr",
-							"value": map[string]interface{}{"bytesValue": getStringValue("resource.bytes.attr", "aGVsbG8gd29ybGQ=")},
+							"value": "aGVsbG8gd29ybGQ=",
 						},
 					},
 				},
@@ -1633,73 +1591,73 @@ func generateComprehensiveOTLPTraceJSON(errorLocation string, invalidValue strin
 								},
 								{
 									"key":   "attribute.bool",
-									"value": map[string]interface{}{"boolValue": getBoolValue("scope.attribute.bool", false)},
+									"value": map[string]interface{}{"boolValue": false},
 								},
 								{
 									"key":   "attribute.double",
-									"value": map[string]interface{}{"doubleValue": getDoubleValue("scope.attribute.double", 789.123)},
+									"value": map[string]interface{}{"doubleValue": 789.123},
 								},
 							},
 						},
 						"spans": []map[string]interface{}{
 							{
-								"traceId":           getTraceId("span.traceId", "AQIDBAUGAAAAAAAAAAAAAAAAAA=="),
-								"spanId":            getSpanId("span.spanId", "AQIDBAUGAA=="),
-								"parentSpanId":      getSpanId("span.parentSpanId", "ERERFREUAAAAAA=="),
+								"traceId":           "AQIDBAUGAAAAAAAAAAAAAAAAAA==",
+								"spanId":            "AQIDBAUGAA==",
+								"parentSpanId":      "ERERFREUAAAAAA==",
 								"name":              "test-span",
 								"kind":              getIntValue("span.kind", 2),
-								"startTimeUnixNano": getTimestamp("span.startTime", "1234567890123456789"),
-								"endTimeUnixNano":   getTimestamp("span.endTime", "1234567890987654321"),
+								"startTimeUnixNano": "1234567890123456789",
+								"endTimeUnixNano":   "1234567890987654321",
 								"attributes": []map[string]interface{}{
 									{
-										"key":   "http.status_code",
-										"value": map[string]interface{}{"intValue": getIntValue("span.http.status_code", 200)},
+										"key":   "attributes.int",
+										"value": map[string]interface{}{"intValue": getIntValue("span.attributes.int", 200)},
 									},
 									{
-										"key":   "custom.bool",
-										"value": map[string]interface{}{"boolValue": getBoolValue("span.custom.bool", true)},
+										"key":   "attributes.bool",
+										"value": map[string]interface{}{"boolValue": true},
 									},
 									{
-										"key":   "custom.double",
-										"value": map[string]interface{}{"doubleValue": getDoubleValue("span.custom.double", 12.34)},
+										"key":   "attributes.double",
+										"value": map[string]interface{}{"doubleValue": 12.34},
 									},
 								},
 								"events": []map[string]interface{}{
 									{
-										"timeUnixNano": getTimestamp("event1.time", "1234567890223456789"),
-										"name":         "cache.hit",
+										"timeUnixNano": "1234567890223456789",
+										"name":         "test-event-1",
 										"attributes": []map[string]interface{}{
 											{
-												"key":   "cache.ttl",
-												"value": map[string]interface{}{"intValue": getIntValue("event1.cache.ttl", 3600)},
+												"key":   "event.int",
+												"value": map[string]interface{}{"intValue": getIntValue("event1.int", 3600)},
 											},
 											{
-												"key":   "cache.hit_ratio",
-												"value": map[string]interface{}{"doubleValue": getDoubleValue("event1.cache.hit_ratio", 0.85)},
+												"key":   "event.double",
+												"value": map[string]interface{}{"doubleValue": 0.85},
 											},
 											{
-												"key":   "cache.enabled",
-												"value": map[string]interface{}{"boolValue": getBoolValue("event1.cache.enabled", true)},
+												"key":   "event.bool",
+												"value": map[string]interface{}{"boolValue": true},
 											},
 										},
 									},
 								},
 								"links": []map[string]interface{}{
 									{
-										"traceId": getTraceId("link1.traceId", "MTIzNDU2Nzg5OnV7PD0+P0E="),
-										"spanId":  getSpanId("link1.spanId", "QUJDREVGRkg="),
+										"traceId": "MTIzNDU2Nzg5OnV7PD0+P0E=",
+										"spanId":  "QUJDREVGRkg=",
 										"attributes": []map[string]interface{}{
 											{
-												"key":   "priority",
-												"value": map[string]interface{}{"intValue": getIntValue("link1.priority", 5)},
+												"key":   "links.int",
+												"value": map[string]interface{}{"intValue": getIntValue("link1.int", 5)},
 											},
 											{
-												"key":   "weight",
-												"value": map[string]interface{}{"doubleValue": getDoubleValue("link1.weight", 0.75)},
+												"key":   "links.double",
+												"value": map[string]interface{}{"doubleValue": 0.75},
 											},
 											{
-												"key":   "active",
-												"value": map[string]interface{}{"boolValue": getBoolValue("link1.active", true)},
+												"key":   "links.bool",
+												"value": map[string]interface{}{"boolValue": true},
 											},
 										},
 									},
@@ -1788,7 +1746,7 @@ func TestUnmarshalTraceRequestDirectJSON_ErrorHandling(t *testing.T) {
 		},
 		{
 			name:     "resource_int_error",
-			jsonData: generateComprehensiveOTLPTraceJSON("resource.process.pid", "not-a-number"),
+			jsonData: generateComprehensiveOTLPTraceJSON("resource.int.attr", "not-a-number"),
 			errorMsg: "invalid syntax",
 		},
 		{
@@ -1798,17 +1756,17 @@ func TestUnmarshalTraceRequestDirectJSON_ErrorHandling(t *testing.T) {
 		},
 		{
 			name:     "span_attribute_int_error",
-			jsonData: generateComprehensiveOTLPTraceJSON("span.http.status_code", "not-a-number"),
+			jsonData: generateComprehensiveOTLPTraceJSON("span.attributes.int", "not-a-number"),
 			errorMsg: "invalid syntax",
 		},
 		{
 			name:     "event_int_error",
-			jsonData: generateComprehensiveOTLPTraceJSON("event1.cache.ttl", "invalid-int"),
+			jsonData: generateComprehensiveOTLPTraceJSON("event1.int", "invalid-int"),
 			errorMsg: "invalid syntax",
 		},
 		{
 			name:     "link_int_error",
-			jsonData: generateComprehensiveOTLPTraceJSON("link1.priority", "invalid-int"),
+			jsonData: generateComprehensiveOTLPTraceJSON("link1.int", "invalid-int"),
 			errorMsg: "invalid syntax",
 		},
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

In [otel-js](https://github.com/open-telemetry/opentelemetry-js/blob/3dc89794a819a3a30fa40b0287eede691f15fb04/experimental/packages/otlp-transformer/src/common/internal.ts#L62), a `intValue` field is set with a number value not as a string. We should handle handle `intValue` field value as a int value as well.

## Short description of the changes

- Add unit tests to make sure we return an error whenever there's a parsing error
- parse `intValue` as either a number or a string

