### PR TITLE
fix(otlp): fix nil pointer in addAttributeToMap

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -451,6 +451,9 @@ func getMarshallableValue(value *common.AnyValue) interface{} {
 // kvlist attributes are flattened to a depth of (maxDepth), if the depth is exceeded, the attribute is added as a JSON string.
 // Bytes and array values are always added as JSON strings.
 func addAttributeToMap(ctx context.Context, result map[string]interface{}, key string, value *common.AnyValue, depth int) {
+	if value == nil {
+		return
+	}
 	switch value.Value.(type) {
 	case *common.AnyValue_StringValue:
 		result[key] = value.GetStringValue()
@@ -477,6 +480,9 @@ func addAttributeToMap(ctx context.Context, result map[string]interface{}, key s
 		} else {
 			// Otherwise, continue flattening
 			for _, entry := range value.GetKvlistValue().Values {
+				if entry.Value == nil {
+					continue
+				}
 				k := key + "." + entry.Key
 				addAttributeToMap(ctx, result, k, entry.Value, depth+1)
 			}

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -395,6 +395,20 @@ func Test_getValue(t *testing.T) {
 				"body.nest.mom": "hi mom",
 			},
 		},
+		{"nil value", nil, map[string]interface{}{}},
+		{"kvlist with nil entry values", &common.AnyValue{
+			Value: &common.AnyValue_KvlistValue{KvlistValue: &common.KeyValueList{
+				Values: []*common.KeyValue{
+					{Key: "valid", Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "test"}}},
+					{Key: "nil_value", Value: nil},
+					{Key: "another_valid", Value: &common.AnyValue{Value: &common.AnyValue_IntValue{IntValue: 42}}},
+				},
+			}}},
+			map[string]interface{}{
+				"body.valid":         "test",
+				"body.another_valid": int64(42),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

- We were encountering a nil pointer exception when processing log data. The exception occurred on line 456 of `addAttributeToMap` when attempting to call methods on a `nil` `entry.value`. ([Sentry issue](https://honeycomb.sentry.io/issues/6633918091/?alert_rule_id=14802393&alert_timestamp=1758951911828&alert_type=email&environment=production&notification_uuid=fd589003-cd01-440b-aba1-0005408deee1&project=4505903518777344&referrer=alert_email))

## Short description of the changes

- I just added a couple nil checks before we attempt further processing of the value.

