### PR TITLE
rel: Prepare v0.39.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Husky Changelog
 
+## v0.39.1 2025-09-29
+
+- fix(otlp): fix nil pointer in addAttributeToMap (#318) | @asdvalenzuela
+
 ## 0.39.0 2025-09-25
 
 - fix: parse intValue from json as either a number or a string (#316) | [Yingrong Zhao](https://github.com/vinozzz)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package husky
 
 var (
-	Version string = "0.39.0"
+	Version string = "0.39.1"
 )


### PR DESCRIPTION
## Which problem is this PR solving?

Prepares the v0.39.1 release.

## Short description of the changes

- Add changelog entry
- Update version to 0.39.0 in version.go

