### PR TITLE
fix(otlp): add nil check in getMarshallableValue to prevent panic

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -417,6 +417,9 @@ func (l *limitedWriter) String() string {
 // are returned as native Go aggregates (maps and slices), rather than marshalled
 // strings (we expect the caller to do the marshalling).
 func getMarshallableValue(value *common.AnyValue) interface{} {
+	if value == nil {
+		return nil
+	}
 	switch value.Value.(type) {
 	case *common.AnyValue_StringValue:
 		return value.GetStringValue()


### PR DESCRIPTION
## Summary
- Add nil check in `getMarshallableValue` function before the switch statement to prevent nil pointer panics
- Add comprehensive unit tests for `getMarshallableValue` to cover all value types and nil cases

## Context
The `getMarshallableValue` function could panic when called with a nil `*common.AnyValue` pointer. This change adds a nil check at the beginning of the function to safely return `nil` instead of panicking.

## Test plan
- Added `TestGetMarshallableValue` with test cases covering:
  - Nil value handling (main fix)
  - All supported value types (string, int, bool, double, bytes, array, kvlist)
  - Edge cases with nil elements in arrays and kvlists
- All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)