### PR TITLE
docs: remove direction to use fork of proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,7 @@
 
 A place to store translation modules to convert custom wire formats to Honeycomb formatted data structures.
 
-IMPORTANT NOTE: most consumers of husky will probably want to use a backwards-compatible version
-of the opentelemetry protobufs. If this applies to you, add the following to your go.mod file:
-
-```go.mod
-replace go.opentelemetry.io/proto/otlp => github.com/honeycombio/opentelemetry-proto-go/otlp v0.19.0
-```
-
 - [OTLP](./otlp/README.md)
-
 
 ## Data Transformations
 


### PR DESCRIPTION
As of v0.43.0, no need to use the fork! Update README to _not_ advise users to replace upstream proto with the old fork.