### PR TITLE
feat: additionally translate event_name proto field into name

### DIFF
--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -77,6 +77,7 @@ func TranslateLogsRequest(ctx context.Context, request *collectorLogs.ExportLogs
 				}
 				if log.EventName != "" {
 					attrs["event.name"] = log.EventName
+					attrs["name"] = log.EventName
 				}
 				if log.Body != nil {
 					// convert the log body to attributes, includes flattening kv pairs into multiple attributes

--- a/otlp/logs_test.go
+++ b/otlp/logs_test.go
@@ -77,6 +77,7 @@ func TestTranslateLogsRequest(t *testing.T) {
 			assert.Equal(t, int32(100), ev.SampleRate)
 			assert.Equal(t, "resource_attr_val", ev.Attributes["resource_attr"])
 			assert.Equal(t, "event_name", ev.Attributes["event.name"])
+			assert.Equal(t, "event_name", ev.Attributes["name"])
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Updates Log translation to set `name` for the LogRecord's `event_name`. This is in addition to the existing translation of `event_name` to `event.name`. This solves 2 problems:

- Allows seemless `group by name` queries with datasets that contain both Spans and OTel Events
- Allows seemless transition in UI features, such as the trace waterfall span view, which has special logic looking for `name` from span event. 

Like for `event.name`, all attributes take precedence.

## Short description of the changes

- update logs translation to also set `name` with `event_name`. 
- upate test.

