### PR TITLE
fix(otlp): handle hex-encoded trace/span IDs in direct JSON path

### DIFF
--- a/otlp/traces_direct_json.go
+++ b/otlp/traces_direct_json.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"strconv"
 	"time"
@@ -696,19 +697,17 @@ func unmarshalSpanJSON(
 
 		switch string(key) {
 		case "traceId":
-			// Trace ID is base64 encoded in JSON
 			strBytes := v.GetStringBytes()
 			var b []byte
-			b, err = base64.StdEncoding.DecodeString(string(strBytes))
+			b, err = decodeIDBytes(string(strBytes))
 			if err == nil {
 				fields.traceID = b
 			}
 
 		case "spanId":
-			// Span ID is base64 encoded in JSON
 			strBytes := v.GetStringBytes()
 			var b []byte
-			b, err = base64.StdEncoding.DecodeString(string(strBytes))
+			b, err = decodeIDBytes(string(strBytes))
 			if err == nil {
 				fields.spanID = b
 			}
@@ -726,10 +725,9 @@ func unmarshalSpanJSON(
 			}
 
 		case "parentSpanId":
-			// Parent span ID is base64 encoded in JSON
 			strBytes := v.GetStringBytes()
 			var b []byte
-			b, err = base64.StdEncoding.DecodeString(string(strBytes))
+			b, err = decodeIDBytes(string(strBytes))
 			if err == nil && len(b) > 0 {
 				fields.parentID = b
 			}
@@ -1146,19 +1144,17 @@ func unmarshalSpanLinkJSON(
 
 		switch string(key) {
 		case "traceId":
-			// Trace ID is base64 encoded in JSON
 			strBytes := v.GetStringBytes()
 			var b []byte
-			b, err = base64.StdEncoding.DecodeString(string(strBytes))
+			b, err = decodeIDBytes(string(strBytes))
 			if err == nil {
 				fields.linkedTraceID = b
 			}
 
 		case "spanId":
-			// Span ID is base64 encoded in JSON
 			strBytes := v.GetStringBytes()
 			var b []byte
-			b, err = base64.StdEncoding.DecodeString(string(strBytes))
+			b, err = decodeIDBytes(string(strBytes))
 			if err == nil {
 				fields.linkedSpanID = b
 			}
@@ -1194,4 +1190,35 @@ func unmarshalSpanLinkJSON(
 	}
 	batch.Events = append(batch.Events, event)
 	return nil
+}
+
+// decodeIDBytes decodes a trace/span ID that may be hex (OTLP JSON spec) or base64 (proto3 JSON).
+func decodeIDBytes(s string) ([]byte, error) {
+	if isHexString(s) {
+		return hex.DecodeString(s)
+	}
+	return base64.StdEncoding.DecodeString(s)
+}
+
+var hexByteTable = [256]bool{
+	'0': true, '1': true, '2': true, '3': true, '4': true,
+	'5': true, '6': true, '7': true, '8': true, '9': true,
+	'a': true, 'b': true, 'c': true, 'd': true, 'e': true, 'f': true,
+	'A': true, 'B': true, 'C': true, 'D': true, 'E': true, 'F': true,
+}
+
+// isHexString reports whether s is a non-empty, even-length string of hex digits.
+func isHexString(s string) bool {
+	if len(s) == 0 || len(s)%2 != 0 {
+		return false
+	}
+	if s[len(s)-1] == '=' {
+		return false // base64 padding — definitely not hex
+	}
+	for i := 0; i < len(s); i++ {
+		if !hexByteTable[s[i]] {
+			return false
+		}
+	}
+	return true
 }

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -65,7 +65,7 @@ func hexToBin(s string) []byte {
 func TestUnmarshalTraceRequestDirect_Complete(t *testing.T) {
 	// Create a comprehensive test request with all supported features
 	// Using human-readable hex strings for clarity
-	traceID1 := "0102030405060708090a0b0c0d0e0f10"
+	traceID1 := "adb975f0528562d20350d5f81f13549d"
 	spanID1 := "0102030405060708"
 	parentSpanID1 := "1112131415161718"
 
@@ -973,6 +973,35 @@ func TestUnmarshalTraceRequestDirect_Complete(t *testing.T) {
 					})
 				}
 			})
+
+			// Only the JSON path is affected: some OTLP clients send trace/span IDs
+			// as lowercase hex strings (per the OTLP JSON spec) rather than base64
+			// (per proto3 JSON). The proto path handles this via a 24-byte compat
+			// shim in BytesToTraceID; verify the direct JSON path does the same.
+			if tc.contentType == "application/json" {
+				t.Run("HexStringIDs", func(t *testing.T) {
+					jsonBody := fmt.Sprintf(`{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"testsvc"}}]},"scopeSpans":[{"spans":[{"traceId":%q,"spanId":%q,"name":"test-span","kind":1,"startTimeUnixNano":"1000000000","endTimeUnixNano":"2000000000"}]}]}]}`,
+						traceID1, spanID1)
+
+					ri := RequestInfo{
+						ApiKey:      "abc123DEF456ghi789jklm",
+						Dataset:     "test-dataset",
+						ContentType: "application/json",
+					}
+					result, err := unmarshalTraceRequestDirectMsgpJSON(context.Background(), []byte(jsonBody), ri)
+					require.NoError(t, err)
+					require.Len(t, result.Batches, 1)
+					require.Len(t, result.Batches[0].Events, 1)
+
+					attrs := decodeMessagePackAttributes(t, result.Batches[0].Events[0].Attributes)
+
+					// Expected: same output as the proto path (BytesToTraceID / BytesToSpanID).
+					// A 32-char hex trace ID decoded as base64 yields 24 bytes; BytesToTraceID
+					// re-encodes those 24 bytes as base64 to recover the original hex string.
+					assert.Equal(t, traceID1, attrs["trace.trace_id"])
+					assert.Equal(t, spanID1, attrs["trace.span_id"])
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

The direct JSON path unconditionally base64-decoded `traceId`, `spanId`, and `parentSpanId`. The OTLP JSON spec says these fields should be lowercase hex strings, but proto3 JSON encoding specifies `bytes` fields as base64. Clients following the OTLP JSON spec (e.g. OTel JS HTTP/JSON exporter) send hex strings, which the direct path double-decoded: treating the 32-char hex string as base64 yields 24 bytes, which then get hex-encoded to a 48-char garbage value instead of the original 32-char ID.

## Changes

- Add `decodeIDBytes(s string)` that detects hex vs base64 and dispatches accordingly, replacing the 5 hardcoded `base64.StdEncoding.DecodeString` calls for trace/span IDs in span and link parsing
- Add `isHexString(s string)` backed by a 256-entry `[256]bool` lookup table; early-exits on `=` (base64 padding) before scanning
- Add `HexStringIDs` sub-test verifying that hex-encoded IDs round-trip correctly through the direct JSON path, matching proto path output

## Test plan

- `go test ./otlp/ -run TestUnmarshalTraceRequestDirect`
- New `HexStringIDs` sub-test covers the reported customer scenario (OTel JS sending hex trace/span IDs via OTLP HTTP/JSON)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)