### PR TITLE
chore: prep for 0.43.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Husky Changelog
 
+## v0.43.1 2026-05-04
+
+### 🐛 Fixes
+
+fix(otlp): handle hex-encoded trace/span IDs in direct JSON path (#355) | [Yingrong Zhao](https://github.com/vinozzZ)
+
 ## v0.43.0 2026-03-06
 
 ### ✨ Added

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package husky
 
 var (
-	Version string = "0.43.0"
+	Version string = "0.43.1"
 )


### PR DESCRIPTION
## Which problem is this PR solving?

updates for releasing #355 

## Short description of the changes

- update version.go to 0.43.1
- update changelog entries

