### PR TITLE
feat: composable header validation, support migrated environments

### DIFF
--- a/otlp/common.go
+++ b/otlp/common.go
@@ -170,6 +170,12 @@ type RequestInfo struct {
 	ApiKey  string
 	Dataset string
 
+	// EnvironmentName is the name of the environment associated with ApiKey,
+	// as reported by auth (e.g. the /1/auth endpoint). Callers set it after
+	// authenticating the key. Blank means the environment behaves as Classic;
+	// non-blank on a classic ApiKey means the environment migrated in place.
+	EnvironmentName string
+
 	UserAgent          string
 	ContentType        string
 	ContentEncoding    string
@@ -180,7 +186,49 @@ func (ri RequestInfo) hasClassicKey() bool {
 	return IsClassicApiKey(ri.ApiKey)
 }
 
+// hasClassicMigratedEnv reports whether ApiKey is a classic key whose
+// environment has been migrated in place to behave like Environments & Services.
+func (ri RequestInfo) hasClassicMigratedEnv() bool {
+	return ri.hasClassicKey() && ri.EnvironmentName != ""
+}
+
+// usesDatasetHeader reports whether a classic key's dataset destination
+// should come from the header: true when the header is present, or when the
+// environment behaves as Classic (where validation already requires it).
+// False only for a migrated environment with no header, whose destination
+// falls back to service.name, as with E&S keys.
+func (ri RequestInfo) usesDatasetHeader() bool {
+	return ri.Dataset != "" || !ri.hasClassicMigratedEnv()
+}
+
+// ValidateHeaders performs the signal-agnostic header/metadata checks shared
+// by all OTLP request types: a supported content-type and a present API key.
+// Signals that require a dataset header should also call ValidateDatasetHeader.
+func (ri *RequestInfo) ValidateHeaders() error {
+	if !IsContentTypeSupported(ri.ContentType) {
+		return ErrInvalidContentType
+	}
+	if len(ri.ApiKey) == 0 {
+		return ErrMissingAPIKeyHeader
+	}
+	return nil
+}
+
+// ValidateDatasetHeader checks the dataset header requirement: classic keys
+// must name a destination dataset, unless the key's environment has migrated
+// in place (non-blank EnvironmentName).
+func (ri *RequestInfo) ValidateDatasetHeader() error {
+	if ri.hasClassicKey() && !ri.hasClassicMigratedEnv() && len(ri.Dataset) == 0 {
+		return ErrMissingDatasetHeader
+	}
+	return nil
+}
+
 // ValidateTracesHeaders validates required headers/metadata for a trace OTLP request
+//
+// Deprecated: use ValidateHeaders and ValidateDatasetHeader. Frozen — ignores
+// EnvironmentName, so a migrated environment's classic key still requires
+// the dataset header here.
 func (ri *RequestInfo) ValidateTracesHeaders() error {
 	if !IsContentTypeSupported(ri.ContentType) {
 		return ErrInvalidContentType
@@ -195,6 +243,10 @@ func (ri *RequestInfo) ValidateTracesHeaders() error {
 }
 
 // ValidateMetricsHeaders validates required headers/metadata for a metric OTLP request
+//
+// Deprecated: use ValidateHeaders and ValidateDatasetHeader. Frozen — ignores
+// EnvironmentName, so a migrated environment's classic key still requires
+// the dataset header here.
 func (ri *RequestInfo) ValidateMetricsHeaders() error {
 	if !IsContentTypeSupported(ri.ContentType) {
 		return ErrInvalidContentType
@@ -209,6 +261,9 @@ func (ri *RequestInfo) ValidateMetricsHeaders() error {
 }
 
 // ValidateLogsHeaders validates required headers/metadata for a logs OTLP request
+//
+// Deprecated: use ValidateHeaders. Logs do not require a dataset header:
+// we settled on a fallback destination for logs in honeycombio/husky#118.
 func (ri *RequestInfo) ValidateLogsHeaders() error {
 	if !IsContentTypeSupported(ri.ContentType) {
 		return ErrInvalidContentType
@@ -216,13 +271,13 @@ func (ri *RequestInfo) ValidateLogsHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
-	// Intentially not requiring a dataset header for classic keys
-	// because we settled on a fallback destination for logs
-	// in honeycombio/husky#118.
 	return nil
 }
 
 // ValidateProfilesHeaders validates required headers/metadata for a profiles OTLP request
+//
+// Deprecated: use ValidateHeaders. Profiles go to the __profiles__ dataset
+// by default; no dataset header is required.
 func (ri *RequestInfo) ValidateProfilesHeaders() error {
 	if !IsContentTypeSupported(ri.ContentType) {
 		return ErrInvalidContentType
@@ -230,7 +285,6 @@ func (ri *RequestInfo) ValidateProfilesHeaders() error {
 	if len(ri.ApiKey) == 0 {
 		return ErrMissingAPIKeyHeader
 	}
-	// Profiles go to __profiles__ dataset by default, no dataset header required
 	return nil
 }
 
@@ -376,7 +430,7 @@ func isInstrumentationLibrary(libraryName string) bool {
 }
 
 func getDataset(ri RequestInfo, attrs map[string]interface{}) string {
-	if ri.hasClassicKey() {
+	if ri.hasClassicKey() && ri.usesDatasetHeader() {
 		return ri.Dataset
 	}
 

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -26,6 +26,19 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Keys in the shapes the validators detect, shared across multiple tests for
+// the same purpose. One representative key per environment type is enough:
+// key-shape detection itself is exhaustively covered by TestIsClassicKey.
+const (
+	classicKey = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+	ensKey     = "abc123DEF456ghi789jklm"
+)
+
+func TestKeyConstantsAreTheShapesTheyClaim(t *testing.T) {
+	require.True(t, IsClassicApiKey(classicKey), "classicKey must be a classic key")
+	require.False(t, IsClassicApiKey(ensKey), "ensKey must not be a classic key")
+}
+
 func TestParseGrpcMetadataIntoRequestInfo(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
 		apiKeyHeader:    "test-api-key",
@@ -124,13 +137,16 @@ func TestAddAttributesToMap(t *testing.T) {
 	}
 }
 
-// ValidateTracesHeaders and ValidateMetricsHeaders are byte-identical; this table
+// ValidateTracesHeaders and ValidateMetricsHeaders are identical; this table
 // asserts both against the same cases so that invariant is enforced, not just implied.
 func TestValidateTracesAndMetricsHeaders(t *testing.T) {
-	const keyClassic = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
-	require.True(t, IsClassicApiKey(keyClassic), "keyClassic must be a classic key")
-	const keyEnS = "abc123DEF456ghi789jklm"
-	require.False(t, IsClassicApiKey(keyEnS), "keyEnS must not be a classic key")
+	signals := []struct {
+		name string
+		fn   func(*RequestInfo) error
+	}{
+		{name: "traces", fn: (*RequestInfo).ValidateTracesHeaders},
+		{name: "metrics", fn: (*RequestInfo).ValidateMetricsHeaders},
+	}
 
 	testCases := []struct {
 		name        string
@@ -141,10 +157,10 @@ func TestValidateTracesAndMetricsHeaders(t *testing.T) {
 	}{
 		{name: "no key, no dataset", apikey: "", dataset: "", contentType: "application/protobuf", err: ErrMissingAPIKeyHeader},
 		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "application/protobuf", err: ErrMissingAPIKeyHeader},
-		{name: "classic/no dataset", apikey: keyClassic, dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
-		{name: "classic/dataset present", apikey: keyClassic, dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "E&S/no dataset", apikey: keyEnS, dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "E&S/dataset present", apikey: keyEnS, dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "classic/no dataset", apikey: classicKey, dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
+		{name: "classic/dataset present", apikey: classicKey, dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "E&S/no dataset", apikey: ensKey, dataset: "", contentType: "application/protobuf", err: nil},
+		{name: "E&S/dataset present", apikey: ensKey, dataset: "dataset", contentType: "application/protobuf", err: nil},
 		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
 		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
 		{name: "content-type/xml", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
@@ -155,35 +171,29 @@ func TestValidateTracesAndMetricsHeaders(t *testing.T) {
 		{name: "content-type/x-protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
 	}
 
-	signals := []struct {
-		name string
-		fn   func(*RequestInfo) error
-	}{
-		{name: "traces", fn: (*RequestInfo).ValidateTracesHeaders},
-		{name: "metrics", fn: (*RequestInfo).ValidateMetricsHeaders},
-	}
+	for _, sig := range signals {
+		t.Run(sig.name, func(t *testing.T) {
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
+					err := sig.fn(&ri)
+					if tc.err != nil {
+						assert.EqualError(t, err, tc.err.Error())
+					} else {
+						assert.NoError(t, err)
+					}
+				})
+			}
 
-	for _, tc := range testCases {
-		for _, sig := range signals {
-			t.Run(sig.name+"/"+tc.name, func(t *testing.T) {
-				ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
-				err := sig.fn(&ri)
-				if tc.err != nil {
-					assert.EqualError(t, err, tc.err.Error())
-				} else {
-					assert.NoError(t, err)
-				}
+			t.Run("deprecated, unaware of migrated environment", func(t *testing.T) {
+				migrated := RequestInfo{ApiKey: classicKey, EnvironmentName: "migrated-env", Dataset: "", ContentType: "application/protobuf"}
+				assert.EqualError(t, sig.fn(&migrated), ErrMissingDatasetHeader.Error(), "deprecated validator stays frozen, EnvironmentName ignored")
 			})
-		}
+		})
 	}
 }
 
 func TestValidateLogsHeaders(t *testing.T) {
-	const keyClassic = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
-	require.True(t, IsClassicApiKey(keyClassic), "keyClassic must be a classic key")
-	const keyEnS = "abc123DEF456ghi789jklm"
-	require.False(t, IsClassicApiKey(keyEnS), "keyEnS must not be a classic key")
-
 	testCases := []struct {
 		name        string
 		apikey      string
@@ -195,10 +205,10 @@ func TestValidateLogsHeaders(t *testing.T) {
 		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "application/protobuf", err: ErrMissingAPIKeyHeader},
 		// logs will use dataset header if present, but log ingest will also use service.name in the data
 		// and we will have a sensible default if neither are present, so a missing dataset header is not an error here
-		{name: "classic/no dataset", apikey: keyClassic, dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "classic/dataset present", apikey: keyClassic, dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "E&S/no dataset", apikey: keyEnS, dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "E&S/dataset present", apikey: keyEnS, dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "classic/no dataset", apikey: classicKey, dataset: "", contentType: "application/protobuf", err: nil},
+		{name: "classic/dataset present", apikey: classicKey, dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "E&S/no dataset", apikey: ensKey, dataset: "", contentType: "application/protobuf", err: nil},
+		{name: "E&S/dataset present", apikey: ensKey, dataset: "dataset", contentType: "application/protobuf", err: nil},
 		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
 		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
 		{name: "content-type/xml", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
@@ -218,6 +228,89 @@ func TestValidateLogsHeaders(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestValidateHeaders(t *testing.T) {
+	testCases := []struct {
+		name        string
+		apikey      string
+		contentType string
+		err         error
+	}{
+		{name: "no key", apikey: "", contentType: "application/protobuf", err: ErrMissingAPIKeyHeader},
+		{name: "classic key ok", apikey: classicKey, contentType: "application/protobuf", err: nil},
+		{name: "E&S key ok", apikey: ensKey, contentType: "application/json", err: nil},
+		{name: "bad content-type", apikey: classicKey, contentType: "application/xml", err: ErrInvalidContentType},
+		{name: "missing content-type", apikey: classicKey, contentType: "", err: ErrInvalidContentType},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType}
+			err := ri.ValidateHeaders()
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateDatasetHeader(t *testing.T) {
+	testCases := []struct {
+		name    string
+		apikey  string
+		envName string
+		dataset string
+		err     error
+	}{
+		{name: "classic env, dataset present", apikey: classicKey, envName: "", dataset: "dataset", err: nil},
+		{name: "migrated env, dataset present", apikey: classicKey, envName: "migrated-env", dataset: "dataset", err: nil},
+		{name: "classic env, no dataset", apikey: classicKey, envName: "", dataset: "", err: ErrMissingDatasetHeader},
+		{name: "migrated env, no dataset", apikey: classicKey, envName: "migrated-env", dataset: "", err: nil},
+		{name: "E&S, dataset present", apikey: ensKey, envName: "ens-env", dataset: "dataset", err: nil},
+		{name: "E&S, no dataset", apikey: ensKey, envName: "ens-env", dataset: "", err: nil},
+		{name: "E&S, no env name, no dataset", apikey: ensKey, envName: "", dataset: "", err: nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ri := RequestInfo{ApiKey: tc.apikey, EnvironmentName: tc.envName, Dataset: tc.dataset}
+			err := ri.ValidateDatasetHeader()
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetDataset(t *testing.T) {
+	withService := map[string]interface{}{"service.name": "svc-from-telemetry"}
+	noService := map[string]interface{}{}
+
+	testCases := []struct {
+		name     string
+		ri       RequestInfo
+		attrs    map[string]interface{}
+		expected string
+	}{
+		{name: "classic env, header present: header wins", ri: RequestInfo{ApiKey: classicKey, Dataset: "from-header"}, attrs: withService, expected: "from-header"},
+		{name: "migrated env, header present: header still wins", ri: RequestInfo{ApiKey: classicKey, EnvironmentName: "migrated-env", Dataset: "from-header"}, attrs: withService, expected: "from-header"},
+		{name: "classic env, no header: empty (validation rejects upstream)", ri: RequestInfo{ApiKey: classicKey}, attrs: withService, expected: ""},
+		{name: "migrated env, no header: service.name", ri: RequestInfo{ApiKey: classicKey, EnvironmentName: "migrated-env"}, attrs: withService, expected: "svc-from-telemetry"},
+		{name: "migrated env, no header, no service.name: default", ri: RequestInfo{ApiKey: classicKey, EnvironmentName: "migrated-env"}, attrs: noService, expected: defaultServiceName},
+		{name: "E&S, header present: service.name, header ignored", ri: RequestInfo{ApiKey: ensKey, Dataset: "from-header"}, attrs: withService, expected: "svc-from-telemetry"},
+		{name: "E&S, no header: same service.name result", ri: RequestInfo{ApiKey: ensKey}, attrs: withService, expected: "svc-from-telemetry"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, getDataset(tc.ri, tc.attrs))
 		})
 	}
 }

--- a/otlp/common_test.go
+++ b/otlp/common_test.go
@@ -124,7 +124,14 @@ func TestAddAttributesToMap(t *testing.T) {
 	}
 }
 
-func TestValidateTracesHeaders(t *testing.T) {
+// ValidateTracesHeaders and ValidateMetricsHeaders are byte-identical; this table
+// asserts both against the same cases so that invariant is enforced, not just implied.
+func TestValidateTracesAndMetricsHeaders(t *testing.T) {
+	const keyClassic = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+	require.True(t, IsClassicApiKey(keyClassic), "keyClassic must be a classic key")
+	const keyEnS = "abc123DEF456ghi789jklm"
+	require.False(t, IsClassicApiKey(keyEnS), "keyEnS must not be a classic key")
+
 	testCases := []struct {
 		name        string
 		apikey      string
@@ -134,14 +141,10 @@ func TestValidateTracesHeaders(t *testing.T) {
 	}{
 		{name: "no key, no dataset", apikey: "", dataset: "", contentType: "application/protobuf", err: ErrMissingAPIKeyHeader},
 		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "application/protobuf", err: ErrMissingAPIKeyHeader},
-		{name: "classic/no dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
-		{name: "classic ingest key/no dataset", apikey: "hcxic_1234567890123456789012345678901234567890123456789012345678", dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
-		{name: "classic/dataset present", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "classic ingest key/dataset present", apikey: "hcxic_1234567890123456789012345678901234567890123456789012345678", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "E&S ingest key/no dataset", apikey: "hcxik_1234567890123456789012345678901234567890123456789012345678", dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "E&S/dataset present", apikey: "abc123DEF456ghi789jklm", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "E&S ingest key/dataset present", apikey: "hcxik_1234567890123456789012345678901234567890123456789012345678", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "classic/no dataset", apikey: keyClassic, dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
+		{name: "classic/dataset present", apikey: keyClassic, dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "E&S/no dataset", apikey: keyEnS, dataset: "", contentType: "application/protobuf", err: nil},
+		{name: "E&S/dataset present", apikey: keyEnS, dataset: "dataset", contentType: "application/protobuf", err: nil},
 		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
 		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
 		{name: "content-type/xml", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
@@ -152,63 +155,35 @@ func TestValidateTracesHeaders(t *testing.T) {
 		{name: "content-type/x-protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
-			err := ri.ValidateTracesHeaders()
-			if tc.err != nil {
-				assert.EqualError(t, tc.err, err.Error())
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestValidateMetricsHeaders(t *testing.T) {
-	testCases := []struct {
-		name        string
-		apikey      string
-		dataset     string
-		contentType string
-		err         error
+	signals := []struct {
+		name string
+		fn   func(*RequestInfo) error
 	}{
-		{name: "no key, no dataset", apikey: "", dataset: "", contentType: "application/protobuf", err: ErrMissingAPIKeyHeader},
-		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "application/protobuf", err: ErrMissingAPIKeyHeader},
-		// classic environments need to tell us which dataset to put metrics in
-		{name: "classic/no dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
-		{name: "classic ingest key/no dataset", apikey: "hcxic_1234567890123456789012345678901234567890123456789012345678", dataset: "", contentType: "application/protobuf", err: ErrMissingDatasetHeader},
-		{name: "classic/dataset present", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "classic ingest key/dataset present", apikey: "hcxic_1234567890123456789012345678901234567890123456789012345678", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		// dataset header not required for E&S, there's a fallback
-		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "E&S ingest key/no dataset", apikey: "hcxik_1234567890123456789012345678901234567890123456789012345678", dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "E&S/dataset present", apikey: "abc123DEF456ghi789jklm", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "E&S ingest key/dataset present", apikey: "hcxik_1234567890123456789012345678901234567890123456789012345678", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
-		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
-		{name: "content-type/xml", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},
-		{name: "content-type/octet-stream", apikey: "apikey", dataset: "dataset", contentType: "application/octet-stream", err: ErrInvalidContentType},
-		{name: "content-type/text-plain", apikey: "apikey", dataset: "dataset", contentType: "text-plain", err: ErrInvalidContentType},
-		{name: "content-type/json", apikey: "apikey", dataset: "dataset", contentType: "application/json", err: nil},
-		{name: "content-type/protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "content-type/x-protobuf", apikey: "apikey", dataset: "dataset", contentType: "application/x-protobuf", err: nil},
+		{name: "traces", fn: (*RequestInfo).ValidateTracesHeaders},
+		{name: "metrics", fn: (*RequestInfo).ValidateMetricsHeaders},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
-			err := ri.ValidateMetricsHeaders()
-			if tc.err != nil {
-				assert.EqualError(t, err, tc.err.Error())
-			} else {
-				assert.NoError(t, err)
-			}
-		})
+		for _, sig := range signals {
+			t.Run(sig.name+"/"+tc.name, func(t *testing.T) {
+				ri := RequestInfo{ApiKey: tc.apikey, ContentType: tc.contentType, Dataset: tc.dataset}
+				err := sig.fn(&ri)
+				if tc.err != nil {
+					assert.EqualError(t, err, tc.err.Error())
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
 	}
 }
 
 func TestValidateLogsHeaders(t *testing.T) {
+	const keyClassic = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+	require.True(t, IsClassicApiKey(keyClassic), "keyClassic must be a classic key")
+	const keyEnS = "abc123DEF456ghi789jklm"
+	require.False(t, IsClassicApiKey(keyEnS), "keyEnS must not be a classic key")
+
 	testCases := []struct {
 		name        string
 		apikey      string
@@ -220,14 +195,10 @@ func TestValidateLogsHeaders(t *testing.T) {
 		{name: "no key, dataset present", apikey: "", dataset: "dataset", contentType: "application/protobuf", err: ErrMissingAPIKeyHeader},
 		// logs will use dataset header if present, but log ingest will also use service.name in the data
 		// and we will have a sensible default if neither are present, so a missing dataset header is not an error here
-		{name: "classic/no dataset", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "classic ingest key/no dataset", apikey: "hcxic_1234567890123456789012345678901234567890123456789012345678", dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "classic/dataset present", apikey: "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "classic ingest key/dataset present", apikey: "hcxic_1234567890123456789012345678901234567890123456789012345678", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "E&S/no dataset", apikey: "abc123DEF456ghi789jklm", dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "E&S ingest key/no dataset", apikey: "hcxik_1234567890123456789012345678901234567890123456789012345678", dataset: "", contentType: "application/protobuf", err: nil},
-		{name: "E&S/dataset present", apikey: "abc123DEF456ghi789jklm", dataset: "dataset", contentType: "application/protobuf", err: nil},
-		{name: "E&S ingest key/dataset present", apikey: "hcxik_1234567890123456789012345678901234567890123456789012345678", dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "classic/no dataset", apikey: keyClassic, dataset: "", contentType: "application/protobuf", err: nil},
+		{name: "classic/dataset present", apikey: keyClassic, dataset: "dataset", contentType: "application/protobuf", err: nil},
+		{name: "E&S/no dataset", apikey: keyEnS, dataset: "", contentType: "application/protobuf", err: nil},
+		{name: "E&S/dataset present", apikey: keyEnS, dataset: "dataset", contentType: "application/protobuf", err: nil},
 		{name: "content-type/(missing)", apikey: "apikey", dataset: "dataset", contentType: "", err: ErrInvalidContentType},
 		{name: "content-type/javascript", apikey: "apikey", dataset: "dataset", contentType: "application/javascript", err: ErrInvalidContentType},
 		{name: "content-type/xml", apikey: "apikey", dataset: "dataset", contentType: "application/xml", err: ErrInvalidContentType},

--- a/otlp/logs.go
+++ b/otlp/logs.go
@@ -23,7 +23,7 @@ func TranslateLogsRequestFromReader(ctx context.Context, body io.ReadCloser, ri 
 // RequestInfo is the parsed information from the HTTP headers
 // maxSize is the maximum size of the request body in bytes
 func TranslateLogsRequestFromReaderSized(ctx context.Context, body io.ReadCloser, ri RequestInfo, maxSize int64) (*TranslateOTLPRequestResult, error) {
-	if err := ri.ValidateLogsHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
 		return nil, err
 	}
 	request := &collectorLogs.ExportLogsServiceRequest{}
@@ -36,7 +36,7 @@ func TranslateLogsRequestFromReaderSized(ctx context.Context, body io.ReadCloser
 // TranslateLogsRequest translates an OTLP proto log request into Honeycomb-friendly structure
 // RequestInfo is the parsed information from the gRPC metadata
 func TranslateLogsRequest(ctx context.Context, request *collectorLogs.ExportLogsServiceRequest, ri RequestInfo) (*TranslateOTLPRequestResult, error) {
-	if err := ri.ValidateLogsHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
 		return nil, err
 	}
 	batches := []Batch{}

--- a/otlp/profiles.go
+++ b/otlp/profiles.go
@@ -21,7 +21,7 @@ func TranslateProfilesRequestFromReader(ctx context.Context, body io.ReadCloser,
 // RequestInfo is the parsed information from the HTTP headers
 // maxSize is the maximum size of the request body in bytes
 func TranslateProfilesRequestFromReaderSized(ctx context.Context, body io.ReadCloser, ri RequestInfo, maxSize int64) (*TranslateOTLPRequestResult, error) {
-	if err := ri.ValidateProfilesHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
 		return nil, err
 	}
 	request := &collectorProfiles.ExportProfilesServiceRequest{}
@@ -41,7 +41,7 @@ func TranslateProfilesRequestFromReaderSized(ctx context.Context, body io.ReadCl
 //  3. Retriever: Parse link_table again, fan out by trace_id, write rows
 //  4. Finalization: Merge dictionaries, optimize storage
 func TranslateProfilesRequest(ctx context.Context, request *collectorProfiles.ExportProfilesServiceRequest, ri RequestInfo) (*TranslateOTLPRequestResult, error) {
-	if err := ri.ValidateProfilesHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
 		return nil, err
 	}
 

--- a/otlp/traces.go
+++ b/otlp/traces.go
@@ -34,7 +34,10 @@ func TranslateTraceRequestFromReader(ctx context.Context, body io.ReadCloser, ri
 // RequestInfo is the parsed information from the HTTP headers
 // maxSize is the maximum size of the request body in bytes
 func TranslateTraceRequestFromReaderSized(ctx context.Context, body io.ReadCloser, ri RequestInfo, maxSize int64) (*TranslateOTLPRequestResult, error) {
-	if err := ri.ValidateTracesHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
+		return nil, err
+	}
+	if err := ri.ValidateDatasetHeader(); err != nil {
 		return nil, err
 	}
 	request := &collectorTrace.ExportTraceServiceRequest{}
@@ -69,7 +72,10 @@ func TranslateTraceRequestFromReaderSizedWithMsgp(
 ) (*TranslateOTLPRequestResultMsgp, error) {
 	defer body.Close()
 
-	if err := ri.ValidateTracesHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
+		return nil, err
+	}
+	if err := ri.ValidateDatasetHeader(); err != nil {
 		return nil, err
 	}
 
@@ -145,7 +151,10 @@ func TranslateTraceRequestFromReaderSizedWithMsgp(
 // TranslateTraceRequest translates an OTLP/gRPC request into Honeycomb-friendly structure
 // RequestInfo is the parsed information from the gRPC metadata
 func TranslateTraceRequest(ctx context.Context, request *collectorTrace.ExportTraceServiceRequest, ri RequestInfo) (*TranslateOTLPRequestResult, error) {
-	if err := ri.ValidateTracesHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
+		return nil, err
+	}
+	if err := ri.ValidateDatasetHeader(); err != nil {
 		return nil, err
 	}
 	var batches []Batch

--- a/otlp/traces_direct.go
+++ b/otlp/traces_direct.go
@@ -456,7 +456,10 @@ func UnmarshalTraceRequestDirectMsgp(
 	data []byte,
 	ri RequestInfo,
 ) (*TranslateOTLPRequestResultMsgp, error) {
-	if err := ri.ValidateTracesHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
+		return nil, err
+	}
+	if err := ri.ValidateDatasetHeader(); err != nil {
 		return nil, err
 	}
 
@@ -1936,7 +1939,7 @@ func marshalAnyToJSON(val any) []byte {
 }
 
 func getDatasetFromMsgpAttr(ri RequestInfo, attrs *msgpAttributes) string {
-	if ri.hasClassicKey() {
+	if ri.hasClassicKey() && ri.usesDatasetHeader() {
 		return ri.Dataset
 	}
 

--- a/otlp/traces_direct_json.go
+++ b/otlp/traces_direct_json.go
@@ -31,7 +31,10 @@ func unmarshalTraceRequestDirectMsgpJSON(
 	data []byte,
 	ri RequestInfo,
 ) (*TranslateOTLPRequestResultMsgp, error) {
-	if err := ri.ValidateTracesHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
+		return nil, err
+	}
+	if err := ri.ValidateDatasetHeader(); err != nil {
 		return nil, err
 	}
 

--- a/otlp/traces_direct_test.go
+++ b/otlp/traces_direct_test.go
@@ -1984,3 +1984,44 @@ func TestUnmarshalTraceRequestDirect_SchemaURL(t *testing.T) {
 		})
 	}
 }
+
+// getDatasetFromMsgpAttr mirrors getDataset's destination selection for
+// the direct-unmarshal fast path.
+func TestGetDatasetFromMsgpAttr(t *testing.T) {
+	withService := &msgpAttributes{serviceName: "svc-from-telemetry"}
+	noService := &msgpAttributes{}
+
+	testCases := []struct {
+		name     string
+		ri       RequestInfo
+		attrs    *msgpAttributes
+		expected string
+	}{
+		{name: "classic env, header present: header wins", ri: RequestInfo{ApiKey: classicKey, Dataset: "from-header"}, attrs: withService, expected: "from-header"},
+		{name: "migrated env, header present: header still wins", ri: RequestInfo{ApiKey: classicKey, EnvironmentName: "migrated-env", Dataset: "from-header"}, attrs: withService, expected: "from-header"},
+		{name: "classic env, no header: empty (validation rejects upstream)", ri: RequestInfo{ApiKey: classicKey}, attrs: withService, expected: ""},
+		{name: "migrated env, no header: service.name", ri: RequestInfo{ApiKey: classicKey, EnvironmentName: "migrated-env"}, attrs: withService, expected: "svc-from-telemetry"},
+		{name: "migrated env, no header, no service.name: default", ri: RequestInfo{ApiKey: classicKey, EnvironmentName: "migrated-env"}, attrs: noService, expected: defaultServiceName},
+		{name: "E&S, header present: service.name, header ignored", ri: RequestInfo{ApiKey: ensKey, Dataset: "from-header"}, attrs: withService, expected: "svc-from-telemetry"},
+		{name: "E&S, no header: same service.name result", ri: RequestInfo{ApiKey: ensKey}, attrs: withService, expected: "svc-from-telemetry"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, getDatasetFromMsgpAttr(tc.ri, tc.attrs))
+		})
+	}
+}
+
+// UnmarshalTraceRequestDirectMsgp calls the split validators, so a migrated
+// environment works through the direct-unmarshal fast path even for a caller
+// whose handler has no validation of its own — this is its only check.
+func TestUnmarshalTraceRequestDirectMsgpHonorsClassicMigratedEnvironment(t *testing.T) {
+	migrated := RequestInfo{ApiKey: classicKey, EnvironmentName: "migrated-env", Dataset: "", ContentType: "application/protobuf"}
+	_, err := UnmarshalTraceRequestDirectMsgp(context.Background(), nil, migrated)
+	assert.NoError(t, err, "migrated env, no dataset header: translation should accept")
+
+	classic := RequestInfo{ApiKey: classicKey, EnvironmentName: "", Dataset: "", ContentType: "application/protobuf"}
+	_, err = UnmarshalTraceRequestDirectMsgp(context.Background(), nil, classic)
+	assert.EqualError(t, err, ErrMissingDatasetHeader.Error(), "classic env, no dataset header: translation still rejects")
+}

--- a/otlp/traces_test.go
+++ b/otlp/traces_test.go
@@ -1493,3 +1493,18 @@ func TestTranslateTraceRequest_SchemaURL(t *testing.T) {
 	assert.Equal(t, resourceSchemaURL, attrs["resource.schema_url"])
 	assert.Equal(t, scopeSchemaURL, attrs["scope.schema_url"])
 }
+
+// TranslateTraceRequest calls the split validators, so a migrated environment
+// works through translation even for callers whose gRPC handler never calls
+// a validator themselves.
+func TestTranslateTraceRequestHonorsClassicMigratedEnvironment(t *testing.T) {
+	emptyReq := &collectortrace.ExportTraceServiceRequest{}
+
+	migrated := RequestInfo{ApiKey: classicKey, EnvironmentName: "migrated-env", Dataset: "", ContentType: "application/protobuf"}
+	_, err := TranslateTraceRequest(context.Background(), emptyReq, migrated)
+	assert.NoError(t, err, "migrated env, no dataset header: translation should accept")
+
+	classic := RequestInfo{ApiKey: classicKey, EnvironmentName: "", Dataset: "", ContentType: "application/protobuf"}
+	_, err = TranslateTraceRequest(context.Background(), emptyReq, classic)
+	assert.EqualError(t, err, ErrMissingDatasetHeader.Error(), "classic env, no dataset header: translation still rejects")
+}


### PR DESCRIPTION
## Problem

A classic API key normally requires a dataset header, since it's the only way husky knows which dataset to write events into. Some environments, though, get migrated in place to behave like Environments & Services (E&S). The customer keeps their classic key, but the environment now assigns datasets by `service.name`, the same way E&S already works. husky's validators don't know about that migration today, so a migrated environment gets rejected for doing exactly what an E&S key can already do. We need to split validation into what can happen before we know the Classicness of an environment (no longer just the key, but also the environment name) and what can only happen after auth (when we learn the environment name). 

Separately, the four existing validators (`ValidateTracesHeaders`, `ValidateMetricsHeaders`, `ValidateLogsHeaders`, `ValidateProfilesHeaders`) duplicate the same content-type and API-key checks, and two of them duplicate the dataset-header check verbatim.

## Changes

### Composable validation

To support Classic environments migrated in place, we need to split the header validations into what needs to be run before authentication and what can only run after authentication.

- Add `ValidateHeaders()` for before auth, primarily to check API key, but also any other check common across signals (content-type)
- Add `ValidateDatasetHeader()` for after auth, because we don't know if the dataset header is required until we know the environment name which we get from auth
  - requires a dataset header if classic key is in use and the environment has not been migrated (determined with new `EnvironmentName` below)

- Add `RequestInfo.EnvironmentName`
  - set by callers after an environment name can be determined (generally after `ValidateHeaders` and auth)
  - blank means the environment behaves as Classic
  - non-blank on a classic key means the environment migrated in place

- Update `getDataset()`/`getDatasetFromMsgpAttr()`
  - follows the same "classic: dataset" vs "migrated: service.name" rule

### Deprecated signal-specific validators

I did _not_ refactor the existing validators to use the new functions. Kept the same logic, so a caller that upgrades husky without touching its call sites keeps current behavior: a classic key still requires the dataset header in those validators, migrated or not.

**I _did_ update several of the transform functions.** These called the signal-specific validators within them and are now updated to use the new composable functions. Callers that don't validate separately on their own before calling transform get the new migrated-environment behavior. Validating separately before calling transform is the new recommendation, though, and can be adopted once a project updates to a version of husky with this change.

### Tests

- Consolidate the duplicate `ValidateTracesHeaders`/`ValidateMetricsHeaders` tables to make clear "these are the same"
- Add coverage for:
  - the new functions across all `EnvironmentName` cases (classic and migrated, crossed with header present and absent, plus E&S)
  - the unchanged deprecated validators' behavior (ignores `EnvironmentName`)
  - the transform functions' new behavior on both the proto and msgpack/direct paths

## Non-breaking

`EnvironmentName`'s zero value reproduces current behavior, so this ships without _requiring_ any caller to change.
