### PR TITLE
fix(codeowners): correct the oss-maintainers team slug

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/oss-maintaners
+* @honeycombio/oss-maintainers


### PR DESCRIPTION
## Which problem is this PR solving?

CODEOWNERS had a typo, so the team wasn't automatically getting review requests.

## Short description of the changes

- Fixes the misspelled team slug in CODEOWNERS.